### PR TITLE
Update FileChooserDialog's Help Path

### DIFF
--- a/modules/desktop-awt/desktop-platform-impl/src/main/java/com/intellij/openapi/fileChooser/ex/FileChooserDialogImpl.java
+++ b/modules/desktop-awt/desktop-platform-impl/src/main/java/com/intellij/openapi/fileChooser/ex/FileChooserDialogImpl.java
@@ -680,6 +680,6 @@ public class FileChooserDialogImpl extends DialogWrapper implements FileChooserD
 
   @Override
   protected String getHelpId() {
-    return "select.path.dialog";
+    return "platform/dialogs/open.dialog";
   }
 }


### PR DESCRIPTION
As suggested by @VISTALL
> select.path.dialog is not valid. need change to *platform/dialogs/open.dialog"