### PR TITLE
Mitigate XXE vulnerability in SimpleXmlReader

### DIFF
--- a/modules/boot/util-nodep/src/main/java/consulo/util/nodep/xml/SimpleXmlReader.java
+++ b/modules/boot/util-nodep/src/main/java/consulo/util/nodep/xml/SimpleXmlReader.java
@@ -39,6 +39,14 @@ public class SimpleXmlReader {
     protected DocumentBuilder initialValue() {
       DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
       try {
+        // Disable external entity processing to prevent XXE attacks
+        dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbFactory.setXIncludeAware(false);
+        dbFactory.setExpandEntityReferences(false);
+
         return dbFactory.newDocumentBuilder();
       }
       catch (ParserConfigurationException e) {


### PR DESCRIPTION
This PR addresses a potential XML External Entity (XXE) vulnerability in the SimpleXmlReader class by securely configuring the DocumentBuilderFactory to disable external entity processing.
The changes ensure that the XML parser is not susceptible to XXE attacks, which could lead to unauthorized access to sensitive files or denial-of-service attacks.

Appreciate time taken to review this!

References
https://github.com/soartech/jsoar/commit/ae6a2ecf1c86488504c498759d9258973cc68387
