### PR TITLE
Added effective LanguageCachedValueTemplate to replace LanguageCachedValueUtil.getCachedValue()

### DIFF
--- a/modules/base/application-api/src/main/java/consulo/application/util/CachedValuesManager.java
+++ b/modules/base/application-api/src/main/java/consulo/application/util/CachedValuesManager.java
@@ -25,6 +25,16 @@ import java.util.concurrent.ConcurrentMap;
  */
 @ServiceAPI(ComponentScope.PROJECT)
 public abstract class CachedValuesManager {
+    public interface ValueTemplate<T, E extends UserDataHolder> {
+        @Nonnull
+        Key<ParameterizedCachedValue<T, E>> getKey();
+
+        @Nonnull
+        ParameterizedCachedValueProvider<T, E> getProvider();
+
+        boolean isTrackValue();
+    }
+
     public static CachedValuesManager getManager(@Nonnull ComponentManager project) {
         return project.getInstance(CachedValuesManager.class);
     }
@@ -84,6 +94,16 @@ public abstract class CachedValuesManager {
             }
         }
         return value.getValue(parameter);
+    }
+
+    public <T, P extends UserDataHolder> T getCachedValue(@Nonnull P dataHolder, @Nonnull ValueTemplate<T, P> valueTemplate) {
+        return getParameterizedCachedValue(
+            dataHolder,
+            valueTemplate.getKey(),
+            valueTemplate.getProvider(),
+            valueTemplate.isTrackValue(),
+            dataHolder
+        );
     }
 
     protected abstract void trackKeyHolder(@Nonnull UserDataHolder dataHolder, @Nonnull Key<?> key);

--- a/modules/base/language-api/src/main/java/consulo/language/psi/util/FileDependencyAddingCachedValueProvider.java
+++ b/modules/base/language-api/src/main/java/consulo/language/psi/util/FileDependencyAddingCachedValueProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2025 consulo.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package consulo.language.psi.util;
+
+import consulo.application.internal.util.CachedValueProfiler;
+import consulo.application.util.CachedValueProvider;
+import consulo.application.util.ParameterizedCachedValueProvider;
+import consulo.language.psi.PsiElement;
+import consulo.language.psi.PsiFile;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * @author UNV
+ * @since 2025-05-25
+ */
+public class FileDependencyAddingCachedValueProvider<T, E extends PsiElement> implements ParameterizedCachedValueProvider<T, E> {
+    @Nonnull
+    private final ParameterizedCachedValueProvider<T, E> myProvider;
+
+    public FileDependencyAddingCachedValueProvider(@Nonnull ParameterizedCachedValueProvider<T, E> provider) {
+        myProvider = provider;
+    }
+
+    @Nullable
+    @Override
+    public CachedValueProvider.Result<T> compute(E context) {
+        CachedValueProvider.Result<T> result = myProvider.compute(context);
+        if (result != null && !context.isPhysical()) {
+            PsiFile file = context.getContainingFile();
+            if (file != null) {
+                CachedValueProvider.Result<T> adjusted = result.addSingleDependency(file);
+                CachedValueProfiler.onResultCreated(adjusted, result);
+                return adjusted;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return myProvider.toString();
+    }
+}

--- a/modules/base/language-api/src/main/java/consulo/language/psi/util/LanguageCachedValueTemplate.java
+++ b/modules/base/language-api/src/main/java/consulo/language/psi/util/LanguageCachedValueTemplate.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2025 consulo.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package consulo.language.psi.util;
+
+import consulo.application.util.CachedValuesManager;
+import consulo.application.util.ParameterizedCachedValue;
+import consulo.application.util.ParameterizedCachedValueProvider;
+import consulo.language.psi.PsiElement;
+import consulo.util.dataholder.Key;
+import jakarta.annotation.Nonnull;
+
+/**
+ * @author UNV
+ * @since 2025-05-25
+ */
+public class LanguageCachedValueTemplate<T, E extends PsiElement> implements CachedValuesManager.ValueTemplate<T, E> {
+    private Key<ParameterizedCachedValue<T, E>> myKey = null;
+    @Nonnull
+    private final ParameterizedCachedValueProvider<T, E> myProvider;
+
+    private LanguageCachedValueTemplate(@Nonnull ParameterizedCachedValueProvider<T, E> provider) {
+        myProvider = new FileDependencyAddingCachedValueProvider<>(provider);
+    }
+
+    public static <T, E extends PsiElement> LanguageCachedValueTemplate<T, E> of(ParameterizedCachedValueProvider<T, E> provider) {
+        return new LanguageCachedValueTemplate<>(provider);
+    }
+
+    @Nonnull
+    @Override
+    public Key<ParameterizedCachedValue<T, E>> getKey() {
+        if (myKey != null) {
+            return myKey;
+        }
+        synchronized (LanguageCachedValueTemplate.class) {
+            if (myKey == null) {
+                myKey = Key.create(myProvider.getClass().getName());
+            }
+            return myKey;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public ParameterizedCachedValueProvider<T, E> getProvider() {
+        return myProvider;
+    }
+
+    @Override
+    public boolean isTrackValue() {
+        return false;
+    }
+}


### PR DESCRIPTION
It uses ParameterizedCachedValueProvider, includes key, doesn't create wrappers on the fly and intended to be stored in a static field.