### PR TITLE
Fixing typo in XxNavigatable class names by creating XxNavigable classes and inheriting XxNavigatable from XxNavigable

### DIFF
--- a/modules/base/build-ui-api/src/main/java/consulo/build/ui/ExecutionNode.java
+++ b/modules/base/build-ui-api/src/main/java/consulo/build/ui/ExecutionNode.java
@@ -15,22 +15,31 @@
  */
 package consulo.build.ui;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.ui.ex.tree.NodeDescriptor;
 import consulo.ui.ex.tree.PresentableNodeDescriptor;
 
 import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 
 /**
  * @author VISTALL
- * @since 01-Aug-22
+ * @since 2022-08-01
  */
 public abstract class ExecutionNode<T extends ExecutionNode<T>> extends PresentableNodeDescriptor<T> {
-  public ExecutionNode(@Nullable NodeDescriptor parentDescriptor) {
-    super(parentDescriptor);
-  }
+    public ExecutionNode(@Nullable NodeDescriptor parentDescriptor) {
+        super(parentDescriptor);
+    }
 
-  
-  public abstract List<Navigatable> getNavigatables();
+    public abstract List<Navigable> getNavigables();
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigables() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation", "unchecked"})
+    public List<Navigatable> getNavigatables() {
+        return (List) getNavigables();
+    }
 }

--- a/modules/base/build-ui-api/src/main/java/consulo/build/ui/event/BuildEventFactory.java
+++ b/modules/base/build-ui-api/src/main/java/consulo/build/ui/event/BuildEventFactory.java
@@ -20,7 +20,7 @@ import consulo.annotation.component.ServiceAPI;
 import consulo.build.ui.BuildDescriptor;
 import consulo.build.ui.FilePosition;
 import consulo.build.ui.issue.BuildIssue;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.ui.notification.Notification;
 import consulo.project.ui.notification.NotificationGroup;
 import org.jspecify.annotations.Nullable;
@@ -74,70 +74,88 @@ public interface BuildEventFactory {
         return createFailure(message, null, Collections.emptyList(), error, null, null);
     }
 
-    default Failure createFailure(@BuildEventsNls.Message String message,
-                                  Throwable error,
-                                  @Nullable Notification notification,
-                                  @Nullable Navigatable navigatable) {
-        return createFailure(message, null, Collections.emptyList(), error, notification, navigatable);
+    default Failure createFailure(
+        @BuildEventsNls.Message String message,
+        Throwable error,
+        @Nullable Notification notification,
+        @Nullable Navigable navigable
+    ) {
+        return createFailure(message, null, Collections.emptyList(), error, notification, navigable);
     }
 
     default Failure createFailure(@BuildEventsNls.Message String message, @BuildEventsNls.Description String description) {
         return createFailure(message, description, List.of(), null, null, null);
     }
 
-    default Failure createFailure(@BuildEventsNls.Message String message,
-                                  @BuildEventsNls.Description String description,
-                                  List<? extends Failure> causes) {
+    default Failure createFailure(
+        @BuildEventsNls.Message String message,
+        @BuildEventsNls.Description String description,
+        List<? extends Failure> causes
+    ) {
         return createFailure(message, description, causes, null, null, null);
     }
 
-    Failure createFailure(@BuildEventsNls.Message String message,
-                          @BuildEventsNls.Description String description,
-                          List<? extends Failure> causes,
-                          @Nullable Throwable error,
-                          @Nullable Notification notification,
-                          @Nullable Navigatable navigatable);
+    Failure createFailure(
+        @BuildEventsNls.Message String message,
+        @BuildEventsNls.Description String description,
+        List<? extends Failure> causes,
+        @Nullable Throwable error,
+        @Nullable Notification notification,
+        @Nullable Navigable navigable
+    );
 
     FailureResult createFailureResult(List<Failure> failures);
 
-    FileMessageEvent createFileMessageEvent(Object parentId,
-                                            MessageEvent.Kind kind,
-                                            NotificationGroup group,
-                                            @BuildEventsNls.Message String message,
-                                            @Nullable @BuildEventsNls.Description String detailedMessage,
-                                            FilePosition filePosition);
+    FileMessageEvent createFileMessageEvent(
+        Object parentId,
+        MessageEvent.Kind kind,
+        NotificationGroup group,
+        @BuildEventsNls.Message String message,
+        @Nullable @BuildEventsNls.Description String detailedMessage,
+        FilePosition filePosition
+    );
 
-    FinishEvent createFinishEvent(Object eventId,
-                                  @Nullable Object parentId,
-                                  long eventTime,
-                                  @BuildEventsNls.Message String message,
-                                  EventResult result);
+    FinishEvent createFinishEvent(
+        Object eventId,
+        @Nullable Object parentId,
+        long eventTime,
+        @BuildEventsNls.Message String message,
+        EventResult result
+    );
 
-    FinishBuildEvent createFinishBuildEvent(Object eventId,
-                                            @Nullable Object parentId,
-                                            long eventTime,
-                                            @BuildEventsNls.Message String message,
-                                            EventResult result);
+    FinishBuildEvent createFinishBuildEvent(
+        Object eventId,
+        @Nullable Object parentId,
+        long eventTime,
+        @BuildEventsNls.Message String message,
+        EventResult result
+    );
 
-    default MessageEvent createMessageEvent(Object parentId,
-                                            MessageEvent.Kind kind,
-                                            NotificationGroup group,
-                                            String message,
-                                            @Nullable String detailedMessage) {
+    default MessageEvent createMessageEvent(
+        Object parentId,
+        MessageEvent.Kind kind,
+        NotificationGroup group,
+        String message,
+        @Nullable String detailedMessage
+    ) {
         return createMessageEvent(parentId, kind, group, message, detailedMessage, null);
     }
 
-    MessageEvent createMessageEvent(Object parentId,
-                                    MessageEvent.Kind kind,
-                                    NotificationGroup group,
-                                    String message,
-                                    @Nullable String detailedMessage,
-                                    @Nullable Navigatable navigatable);
+    MessageEvent createMessageEvent(
+        Object parentId,
+        MessageEvent.Kind kind,
+        NotificationGroup group,
+        String message,
+        @Nullable String detailedMessage,
+        @Nullable Navigable navigable
+    );
 
-    StartEvent createStartEvent(Object eventId,
-                                @Nullable Object parentId,
-                                long eventTime,
-                                @BuildEventsNls.Message String message);
+    StartEvent createStartEvent(
+        Object eventId,
+        @Nullable Object parentId,
+        long eventTime,
+        @BuildEventsNls.Message String message
+    );
 
     BuildIssueEvent createBuildIssueEvent(
         Object parentId,
@@ -151,5 +169,10 @@ public interface BuildEventFactory {
         return createOutputBuildEvent(new Object(), parentId, message, stdOut);
     }
 
-    OutputBuildEvent createOutputBuildEvent(Object eventId, @Nullable Object parentId, @BuildEventsNls.Message String message, boolean stdOut);
+    OutputBuildEvent createOutputBuildEvent(
+        Object eventId,
+        @Nullable Object parentId,
+        @BuildEventsNls.Message String message,
+        boolean stdOut
+    );
 }

--- a/modules/base/build-ui-api/src/main/java/consulo/build/ui/event/Failure.java
+++ b/modules/base/build-ui-api/src/main/java/consulo/build/ui/event/Failure.java
@@ -15,27 +15,45 @@
  */
 package consulo.build.ui.event;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.project.ui.notification.Notification;
 import consulo.navigation.Navigatable;
 
 import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 
 /**
  * @author Vladislav.Soroka
  */
 public interface Failure {
-  @BuildEventsNls.Message
-  @Nullable String getMessage();
+    @BuildEventsNls.Message
+    @Nullable
+    String getMessage();
 
-  @BuildEventsNls.Description
-  @Nullable String getDescription();
+    @BuildEventsNls.Description
+    @Nullable
+    String getDescription();
 
-  default @Nullable Throwable getError() {return null;}
+    default @Nullable Throwable getError() {
+        return null;
+    }
 
-  List<? extends Failure> getCauses();
+    List<? extends Failure> getCauses();
 
-  default @Nullable Notification getNotification() {return null;}
+    default @Nullable Notification getNotification() {
+        return null;
+    }
 
-  default @Nullable Navigatable getNavigatable() {return null;}
+    default @Nullable Navigable getNavigable() {
+        return null;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable() {
+        return (Navigatable) getNavigable();
+    }
 }

--- a/modules/base/build-ui-api/src/main/java/consulo/build/ui/event/MessageEvent.java
+++ b/modules/base/build-ui-api/src/main/java/consulo/build/ui/event/MessageEvent.java
@@ -1,10 +1,11 @@
 // Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package consulo.build.ui.event;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.project.ui.notification.NotificationGroup;
-
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -19,13 +20,19 @@ public interface MessageEvent extends BuildEvent {
         SIMPLE
     }
 
-    
     Kind getKind();
 
-    
     NotificationGroup getGroup();
 
-    @Nullable Navigatable getNavigatable(Project project);
+    @Nullable
+    Navigable getNavigable(Project project);
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable(Project project) {
+        return (Navigatable) getNavigable(project);
+    }
 
     MessageEventResult getResult();
 }

--- a/modules/base/build-ui-api/src/main/java/consulo/build/ui/issue/BuildIssue.java
+++ b/modules/base/build-ui-api/src/main/java/consulo/build/ui/issue/BuildIssue.java
@@ -15,27 +15,35 @@
  */
 package consulo.build.ui.issue;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.navigation.Navigatable;
 
 import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 
 /**
+ * From kotlin
+ *
  * @author VISTALL
- * @since 14/01/2021
- * <p>
- * from kotlin
+ * @since 2021-01-14
  */
 public interface BuildIssue {
-  
-  String getTitle();
+    String getTitle();
 
-  
-  String getDescription();
+    String getDescription();
 
-  
-  List<BuildIssueQuickFix> getQuickFixes();
+    List<BuildIssueQuickFix> getQuickFixes();
 
-  @Nullable Navigatable getNavigatable(Project project);
+    @Nullable
+    Navigable getNavigable(Project project);
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable(Project project) {
+        return (Navigatable) getNavigable(project);
+    }
 }

--- a/modules/base/build-ui-api/src/main/java/consulo/build/ui/progress/BuildProgress.java
+++ b/modules/base/build-ui-api/src/main/java/consulo/build/ui/progress/BuildProgress.java
@@ -5,7 +5,7 @@ import consulo.build.ui.FilePosition;
 import consulo.build.ui.event.BuildEventsNls;
 import consulo.build.ui.event.MessageEvent;
 import consulo.build.ui.issue.BuildIssue;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import org.jspecify.annotations.Nullable;
 
 public interface BuildProgress<T extends BuildProgressDescriptor> {
@@ -25,7 +25,7 @@ public interface BuildProgress<T extends BuildProgressDescriptor> {
         @BuildEventsNls.Title String title,
         @BuildEventsNls.Message String message,
         MessageEvent.Kind kind,
-        @Nullable Navigatable navigatable
+        @Nullable Navigable navigable
     );
 
     BuildProgress<T> fileMessage(

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/BuildProgressImpl.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/BuildProgressImpl.java
@@ -11,7 +11,7 @@ import consulo.build.ui.progress.BuildProgress;
 import consulo.build.ui.progress.BuildProgressDescriptor;
 import consulo.build.ui.progress.BuildProgressListener;
 import consulo.compiler.CompilerManager;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.util.collection.Lists;
 import org.jspecify.annotations.Nullable;
@@ -46,13 +46,11 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
         }
     }
 
-    
     @Override
     public Object getId() {
         return myId;
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> start(BuildProgressDescriptor descriptor) {
         myDescriptor = descriptor;
@@ -61,13 +59,11 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
         return this;
     }
 
-    
     protected StartEvent createStartEvent(BuildProgressDescriptor descriptor) {
         assert myParentProgress != null;
         return new StartEventImpl(getId(), myParentProgress.getId(), System.currentTimeMillis(), descriptor.getTitle());
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> startChildProgress(String title) {
         BuildDescriptor buildDescriptor = myDescriptor.getBuildDescriptor();
@@ -75,49 +71,47 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
         progress.myListeners.addAll(myListeners);
         return progress.start(new BuildProgressDescriptor() {
 
-            
+
             @Override
             public String getTitle() {
                 return title;
             }
 
             @Override
-            public
-            
-            BuildDescriptor getBuildDescriptor() {
+            public BuildDescriptor getBuildDescriptor() {
                 return buildDescriptor;
             }
         });
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> progress(String title) {
         return progress(title, -1, -1, "");
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> progress(String title, long total, long progress, String unit) {
         Object parentId = myParentProgress != null ? myParentProgress.getId() : null;
-        onEvent(getBuildId(),
-            new ProgressBuildEventImpl(getId(), parentId, System.currentTimeMillis(), title, total, progress, unit));
+        onEvent(
+            getBuildId(),
+            new ProgressBuildEventImpl(getId(), parentId, System.currentTimeMillis(), title, total, progress, unit)
+        );
         return this;
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> output(String text, boolean stdOut) {
         onEvent(getBuildId(), new OutputBuildEventImpl(getId(), text, stdOut));
         return this;
     }
 
-    
     @Override
-    public BuildProgress<BuildProgressDescriptor> fileMessage(String title,
-                                                              String message,
-                                                              MessageEvent.Kind kind,
-                                                              FilePosition filePosition) {
+    public BuildProgress<BuildProgressDescriptor> fileMessage(
+        String title,
+        String message,
+        MessageEvent.Kind kind,
+        FilePosition filePosition
+    ) {
         StringBuilder fileLink = new StringBuilder(filePosition.getFile().getPath());
         if (filePosition.getStartLine() > 0) {
             fileLink.append(":").append(filePosition.getStartLine() + 1);
@@ -132,41 +126,38 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
         return this;
     }
 
-    
     @Override
-    public BuildProgress<BuildProgressDescriptor> message(String title,
-                                                          String message,
-                                                          MessageEvent.Kind kind,
-                                                          @Nullable Navigatable navigatable) {
+    public BuildProgress<BuildProgressDescriptor> message(
+        String title,
+        String message,
+        MessageEvent.Kind kind,
+        @Nullable Navigable navigable
+    ) {
         MessageEventImpl event = new MessageEventImpl(getId(), kind, BuildNotificationsGroups.BUILD_ISSUES, title, message) {
             @Override
-            public @Nullable Navigatable getNavigatable(Project project) {
-                return navigatable;
+            public @Nullable Navigable getNavigable(Project project) {
+                return navigable;
             }
         };
         onEvent(getBuildId(), event);
         return this;
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> finish() {
         return finish(false);
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> finish(boolean isUpToDate) {
         return finish(System.currentTimeMillis(), isUpToDate, myDescriptor.getTitle());
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> finish(long timeStamp) {
         return finish(timeStamp, false, myDescriptor.getTitle());
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> finish(long timeStamp, boolean isUpToDate, String message) {
         assertStarted();
@@ -177,13 +168,11 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
         return myParentProgress;
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> fail() {
         return fail(System.currentTimeMillis(), myDescriptor.getTitle());
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> fail(long timeStamp, String message) {
         assertStarted();
@@ -193,13 +182,11 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
         return myParentProgress;
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> cancel() {
         return cancel(System.currentTimeMillis(), myDescriptor.getTitle());
     }
 
-    
     @Override
     public BuildProgress<BuildProgressDescriptor> cancel(long timeStamp, String message) {
         assertStarted();
@@ -210,7 +197,6 @@ public class BuildProgressImpl implements BuildProgress<BuildProgressDescriptor>
     }
 
     @Override
-    
     public BuildProgress<BuildProgressDescriptor> buildIssue(BuildIssue issue, MessageEvent.Kind kind) {
         onEvent(getBuildId(), new BuildIssueEventImpl(getId(), issue, kind));
         return this;

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/BuildEventFactoryImpl.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/BuildEventFactoryImpl.java
@@ -20,7 +20,7 @@ import consulo.build.ui.BuildDescriptor;
 import consulo.build.ui.FilePosition;
 import consulo.build.ui.event.*;
 import consulo.build.ui.issue.BuildIssue;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.ui.notification.Notification;
 import consulo.project.ui.notification.NotificationGroup;
 import jakarta.inject.Singleton;
@@ -36,7 +36,6 @@ import java.util.function.Supplier;
 @ServiceImpl
 @Singleton
 public class BuildEventFactoryImpl implements BuildEventFactory {
-
     @Override
     public SkippedResult createSkippedResult() {
         return new SkippedResultImpl();
@@ -53,8 +52,15 @@ public class BuildEventFactoryImpl implements BuildEventFactory {
     }
 
     @Override
-    public Failure createFailure(String message, String description, List<? extends Failure> causes, @Nullable Throwable error, @Nullable Notification notification, @Nullable Navigatable navigatable) {
-        return new FailureImpl(message, description, causes, error, notification, navigatable);
+    public Failure createFailure(
+        String message,
+        String description,
+        List<? extends Failure> causes,
+        @Nullable Throwable error,
+        @Nullable Notification notification,
+        @Nullable Navigable navigable
+    ) {
+        return new FailureImpl(message, description, causes, error, notification, navigable);
     }
 
     @Override
@@ -63,12 +69,14 @@ public class BuildEventFactoryImpl implements BuildEventFactory {
     }
 
     @Override
-    public FileMessageEvent createFileMessageEvent(Object parentId,
-                                                   MessageEvent.Kind kind,
-                                                   NotificationGroup group,
-                                                   String message,
-                                                   @Nullable String detailedMessage,
-                                                   FilePosition filePosition) {
+    public FileMessageEvent createFileMessageEvent(
+        Object parentId,
+        MessageEvent.Kind kind,
+        NotificationGroup group,
+        String message,
+        @Nullable String detailedMessage,
+        FilePosition filePosition
+    ) {
         return new FileMessageEventImpl(parentId, kind, group, message, detailedMessage, filePosition);
     }
 
@@ -78,18 +86,26 @@ public class BuildEventFactoryImpl implements BuildEventFactory {
     }
 
     @Override
-    public FinishBuildEvent createFinishBuildEvent(Object eventId, @Nullable Object parentId, long eventTime, String message, EventResult result) {
+    public FinishBuildEvent createFinishBuildEvent(
+        Object eventId,
+        @Nullable Object parentId,
+        long eventTime,
+        String message,
+        EventResult result
+    ) {
         return new FinishBuildEventImpl(eventId, parentId, eventTime, message, result);
     }
 
     @Override
-    public MessageEvent createMessageEvent(Object parentId,
-                                           MessageEvent.Kind kind,
-                                           NotificationGroup group,
-                                           String message,
-                                           @Nullable String detailedMessage,
-                                           @Nullable Navigatable navigatable) {
-        return new MessageEventImpl(parentId, kind, group, message, detailedMessage, navigatable);
+    public MessageEvent createMessageEvent(
+        Object parentId,
+        MessageEvent.Kind kind,
+        NotificationGroup group,
+        String message,
+        @Nullable String detailedMessage,
+        @Nullable Navigable navigable
+    ) {
+        return new MessageEventImpl(parentId, kind, group, message, detailedMessage, navigable);
     }
 
     @Override

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/BuildIssueEventImpl.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/BuildIssueEventImpl.java
@@ -5,67 +5,61 @@ import consulo.build.ui.BuildNotificationsGroups;
 import consulo.build.ui.event.BuildIssueEvent;
 import consulo.build.ui.event.MessageEventResult;
 import consulo.build.ui.issue.BuildIssue;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.ui.notification.NotificationGroup;
-
 import org.jspecify.annotations.Nullable;
 
 /**
  * @author Vladislav.Soroka
  */
 public class BuildIssueEventImpl extends AbstractBuildEvent implements BuildIssueEvent {
-  private final BuildIssue myIssue;
-  private final Kind myKind;
+    private final BuildIssue myIssue;
+    private final Kind myKind;
 
-  public BuildIssueEventImpl(Object parentId, BuildIssue buildIssue, Kind kind) {
-    super(new Object(), parentId, System.currentTimeMillis(), buildIssue.getTitle());
-    myIssue = buildIssue;
-    myKind = kind;
-  }
+    public BuildIssueEventImpl(Object parentId, BuildIssue buildIssue, Kind kind) {
+        super(new Object(), parentId, System.currentTimeMillis(), buildIssue.getTitle());
+        myIssue = buildIssue;
+        myKind = kind;
+    }
 
-  
-  @Override
-  public final String getDescription() {
-    return myIssue.getDescription();
-  }
-
-  
-  @Override
-  public BuildIssue getIssue() {
-    return myIssue;
-  }
-
-  
-  @Override
-  public Kind getKind() {
-    return myKind;
-  }
-
-  
-  @Override
-  public NotificationGroup getGroup() {
-    return BuildNotificationsGroups.BUILD_ISSUES;
-  }
-
-  @Override
-  public @Nullable Navigatable getNavigatable(Project project) {
-    return myIssue.getNavigatable(project);
-  }
-
-  @Override
-  public MessageEventResult getResult() {
-    return new MessageEventResult() {
-      @Override
-      public Kind getKind() {
-        return myKind;
-      }
-
-      
-      @Override
-      public String getDetails() {
+    @Override
+    public final String getDescription() {
         return myIssue.getDescription();
-      }
-    };
-  }
+    }
+
+    @Override
+    public BuildIssue getIssue() {
+        return myIssue;
+    }
+
+    @Override
+    public Kind getKind() {
+        return myKind;
+    }
+
+    @Override
+    public NotificationGroup getGroup() {
+        return BuildNotificationsGroups.BUILD_ISSUES;
+    }
+
+    @Override
+    public @Nullable Navigable getNavigable(Project project) {
+        return myIssue.getNavigable(project);
+    }
+
+    @Override
+    public MessageEventResult getResult() {
+        return new MessageEventResult() {
+            @Override
+            public Kind getKind() {
+                return myKind;
+            }
+
+            @Override
+            public String getDetails() {
+                return myIssue.getDescription();
+            }
+        };
+    }
 }

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FailureImpl.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FailureImpl.java
@@ -17,7 +17,7 @@ package consulo.build.ui.impl.internal.event;
 
 import consulo.build.ui.event.BuildEventsNls;
 import consulo.build.ui.event.Failure;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.ui.notification.Notification;
 import org.jspecify.annotations.Nullable;
 
@@ -28,79 +28,81 @@ import java.util.List;
  * @author Vladislav.Soroka
  */
 public class FailureImpl implements Failure {
-  private final @BuildEventsNls.Message String myMessage;
-  private final @BuildEventsNls.Description String myDescription;
-  private final List<? extends Failure> myCauses;
-  private final @Nullable Throwable myError;
-  private final @Nullable Notification myNotification;
-  private final @Nullable Navigatable myNavigatable;
+    private final @BuildEventsNls.Message String myMessage;
+    private final @BuildEventsNls.Description String myDescription;
+    private final List<? extends Failure> myCauses;
+    private final @Nullable Throwable myError;
+    private final @Nullable Notification myNotification;
+    private final @Nullable Navigable myNavigable;
 
-  public FailureImpl(@BuildEventsNls.Message String message, Throwable error) {
-    this(message, null, Collections.emptyList(), error, null, null);
-  }
+    public FailureImpl(@BuildEventsNls.Message String message, Throwable error) {
+        this(message, null, Collections.emptyList(), error, null, null);
+    }
 
-  public FailureImpl(
-    @BuildEventsNls.Message String message,
-    Throwable error,
-    @Nullable Notification notification,
-    @Nullable Navigatable navigatable
-  ) {
-    this(message, null, Collections.emptyList(), error, notification, navigatable);
-  }
+    public FailureImpl(
+        @BuildEventsNls.Message String message,
+        Throwable error,
+        @Nullable Notification notification,
+        @Nullable Navigable navigable
+    ) {
+        this(message, null, Collections.emptyList(), error, notification, navigable);
+    }
 
-  public FailureImpl(@BuildEventsNls.Message String message, @BuildEventsNls.Description String description) {
-    this(message, description, Collections.emptyList(), null, null, null);
-  }
+    public FailureImpl(@BuildEventsNls.Message String message, @BuildEventsNls.Description String description) {
+        this(message, description, Collections.emptyList(), null, null, null);
+    }
 
-  public FailureImpl(@BuildEventsNls.Message String message,
-                     @BuildEventsNls.Description String description,
-                     List<? extends Failure> causes) {
-    this(message, description, causes, null, null, null);
-  }
+    public FailureImpl(
+        @BuildEventsNls.Message String message,
+        @BuildEventsNls.Description String description,
+        List<? extends Failure> causes
+    ) {
+        this(message, description, causes, null, null, null);
+    }
 
-  public FailureImpl(
-    @BuildEventsNls.Message String message,
-    @BuildEventsNls.Description String description,
-    List<? extends Failure> causes,
-    @Nullable Throwable error,
-    @Nullable Notification notification,
-    @Nullable Navigatable navigatable
-  ) {
-    myMessage = message;
-    myDescription = description;
-    myCauses = causes;
-    myError = error;
-    myNotification = notification;
-    myNavigatable = navigatable;
-  }
+    public FailureImpl(
+        @BuildEventsNls.Message String message,
+        @BuildEventsNls.Description String description,
+        List<? extends Failure> causes,
+        @Nullable Throwable error,
+        @Nullable Notification notification,
+        @Nullable Navigable navigable
+    ) {
+        myMessage = message;
+        myDescription = description;
+        myCauses = causes;
+        myError = error;
+        myNotification = notification;
+        myNavigable = navigable;
+    }
 
-  @Override
-  public @Nullable String getMessage() {
-    return myMessage;
-  }
+    @Override
+    public @Nullable String getMessage() {
+        return myMessage;
+    }
 
-  @Override
-  public @Nullable String getDescription() {
-    return myDescription;
-  }
+    @Override
+    public @Nullable String getDescription() {
+        return myDescription;
+    }
 
-  @Override
-  public @Nullable Throwable getError() {
-    return myError;
-  }
+    @Override
+    public @Nullable Throwable getError() {
+        return myError;
+    }
 
-  @Override
-  public List<? extends Failure> getCauses() {
-    return myCauses;
-  }
+    @Override
+    public List<? extends Failure> getCauses() {
+        return myCauses;
+    }
 
-  @Override
-  public @Nullable Notification getNotification() {
-    return myNotification;
-  }
+    @Override
+    public @Nullable Notification getNotification() {
+        return myNotification;
+    }
 
-  @Override
-  public @Nullable Navigatable getNavigatable() {
-    return myNavigatable;
-  }
+    @Override
+    public @Nullable Navigable getNavigable() {
+        return myNavigable;
+    }
 }

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FileMessageEventImpl.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FileMessageEventImpl.java
@@ -5,7 +5,7 @@ import consulo.build.ui.FilePosition;
 import consulo.build.ui.event.BuildEventsNls;
 import consulo.build.ui.event.FileMessageEvent;
 import consulo.build.ui.event.FileMessageEventResult;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.ui.notification.NotificationGroup;
 import org.jspecify.annotations.Nullable;
@@ -64,12 +64,12 @@ public class FileMessageEventImpl extends MessageEventImpl implements FileMessag
   }
 
   @Override
-  public @Nullable Navigatable getNavigatable(Project project) {
-    return new FileNavigatable(project, myFilePosition);
+  public @Nullable Navigable getNavigable(Project project) {
+    return new FileNavigable(project, myFilePosition);
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FileNavigable.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FileNavigable.java
@@ -1,0 +1,74 @@
+// Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package consulo.build.ui.impl.internal.event;
+
+import consulo.annotation.access.RequiredReadAction;
+import consulo.build.ui.FilePosition;
+import consulo.navigation.Navigable;
+import consulo.navigation.Navigatable;
+import consulo.navigation.OpenFileDescriptor;
+import consulo.navigation.OpenFileDescriptorFactory;
+import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
+import consulo.util.lang.lazy.LazyValue;
+import consulo.virtualFileSystem.VirtualFile;
+import consulo.virtualFileSystem.util.VirtualFileUtil;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Vladislav.Soroka
+ */
+@SuppressWarnings("deprecation")
+public class FileNavigable implements Navigatable {
+    private final Project myProject;
+    private final Supplier<OpenFileDescriptor> myValue;
+    private final FilePosition myFilePosition;
+
+    public FileNavigable(Project project, FilePosition filePosition) {
+        myProject = project;
+        myFilePosition = filePosition;
+        myValue = LazyValue.nullable(this::createDescriptor);
+    }
+
+    @Override
+    @RequiredUIAccess
+    public void navigate(boolean requestFocus) {
+        Navigable descriptor = getFileDescriptor();
+        if (descriptor != null) {
+            descriptor.navigate(requestFocus);
+        }
+    }
+
+    @Override
+    @RequiredReadAction
+    public boolean canNavigate() {
+        Navigable descriptor = getFileDescriptor();
+        return descriptor != null && descriptor.canNavigate();
+    }
+
+    @Override
+    @RequiredReadAction
+    public boolean canNavigateToSource() {
+        Navigable descriptor = getFileDescriptor();
+        return descriptor != null && descriptor.canNavigateToSource();
+    }
+
+    public @Nullable OpenFileDescriptor getFileDescriptor() {
+        return myValue.get();
+    }
+
+    public FilePosition getFilePosition() {
+        return myFilePosition;
+    }
+
+    private @Nullable OpenFileDescriptor createDescriptor() {
+        OpenFileDescriptor descriptor = null;
+        VirtualFile file = VirtualFileUtil.findFileByIoFile(myFilePosition.getFile(), false);
+        if (file != null) {
+            OpenFileDescriptorFactory factory = OpenFileDescriptorFactory.getInstance(myProject);
+            descriptor = factory.newBuilder(file).line(myFilePosition.getStartLine()).column(myFilePosition.getStartColumn()).build();
+        }
+        return descriptor;
+    }
+}

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FileNavigatable.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/FileNavigatable.java
@@ -1,74 +1,18 @@
 // Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package consulo.build.ui.impl.internal.event;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.build.ui.FilePosition;
-import consulo.navigation.Navigatable;
-import consulo.navigation.OpenFileDescriptor;
-import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.project.Project;
-import consulo.util.lang.lazy.LazyValue;
-import consulo.virtualFileSystem.VirtualFile;
-import consulo.virtualFileSystem.util.VirtualFileUtil;
-import org.jspecify.annotations.Nullable;
-
-import java.util.function.Supplier;
 
 /**
  * @author Vladislav.Soroka
  */
-public class FileNavigatable implements Navigatable {
-  private final Project myProject;
-  private final Supplier<OpenFileDescriptor> myValue;
-  private final FilePosition myFilePosition;
-
-  public FileNavigatable(Project project, FilePosition filePosition) {
-    myProject = project;
-    myFilePosition = filePosition;
-    myValue = LazyValue.nullable(this::createDescriptor);
-  }
-
-  @Override
-  public void navigate(boolean requestFocus) {
-    Navigatable descriptor = getFileDescriptor();
-    if (descriptor != null) {
-      descriptor.navigate(requestFocus);
+@Deprecated
+@DeprecationInfo("Use FileNavigable, typo-corrected class name")
+@SuppressWarnings("SpellCheckingInspection")
+public class FileNavigatable extends FileNavigable {
+    public FileNavigatable(Project project, FilePosition filePosition) {
+        super(project, filePosition);
     }
-  }
-
-  @Override
-  public boolean canNavigate() {
-    Navigatable descriptor = getFileDescriptor();
-    if (descriptor != null) {
-      return descriptor.canNavigate();
-    }
-    return false;
-  }
-
-  @Override
-  public boolean canNavigateToSource() {
-    Navigatable descriptor = getFileDescriptor();
-    if (descriptor != null) {
-      return descriptor.canNavigateToSource();
-    }
-    return false;
-  }
-
-  public @Nullable OpenFileDescriptor getFileDescriptor() {
-    return myValue.get();
-  }
-
-  
-  public FilePosition getFilePosition() {
-    return myFilePosition;
-  }
-
-  private @Nullable OpenFileDescriptor createDescriptor() {
-    OpenFileDescriptor descriptor = null;
-    VirtualFile file = VirtualFileUtil.findFileByIoFile(myFilePosition.getFile(), false);
-    if (file != null) {
-      OpenFileDescriptorFactory factory = OpenFileDescriptorFactory.getInstance(myProject);
-      descriptor = factory.newBuilder(file).line(myFilePosition.getStartLine()).column(myFilePosition.getStartColumn()).build();
-    }
-    return descriptor;
-  }
 }

--- a/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/MessageEventImpl.java
+++ b/modules/base/build-ui-impl/src/main/java/consulo/build/ui/impl/internal/event/MessageEventImpl.java
@@ -4,7 +4,7 @@ package consulo.build.ui.impl.internal.event;
 import consulo.build.ui.event.BuildEventsNls;
 import consulo.build.ui.event.MessageEvent;
 import consulo.build.ui.event.MessageEventResult;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.ui.notification.NotificationGroup;
 import org.jspecify.annotations.Nullable;
@@ -15,31 +15,33 @@ import java.util.Objects;
  * @author Vladislav.Soroka
  */
 public class MessageEventImpl extends AbstractBuildEvent implements MessageEvent {
-
-    
     private final Kind myKind;
-    
-    private final NotificationGroup myGroup;
-    private final @Nullable Navigatable myNavigatable;
 
-    public MessageEventImpl(Object parentId,
-                            Kind kind,
-                            NotificationGroup group,
-                            String message,
-                            @Nullable String detailedMessage) {
+    private final NotificationGroup myGroup;
+    private final @Nullable Navigable myNavigable;
+
+    public MessageEventImpl(
+        Object parentId,
+        Kind kind,
+        NotificationGroup group,
+        String message,
+        @Nullable String detailedMessage
+    ) {
         this(parentId, kind, group, message, detailedMessage, null);
     }
 
-    public MessageEventImpl(Object parentId,
-                            Kind kind,
-                            NotificationGroup group,
-                            String message,
-                            @Nullable String detailedMessage,
-                            @Nullable Navigatable navigatable) {
+    public MessageEventImpl(
+        Object parentId,
+        Kind kind,
+        NotificationGroup group,
+        String message,
+        @Nullable String detailedMessage,
+        @Nullable Navigable navigable
+    ) {
         super(new Object(), parentId, System.currentTimeMillis(), message);
         myKind = kind;
         myGroup = group;
-        myNavigatable = navigatable;
+        myNavigable = navigable;
         setDescription(detailedMessage);
     }
 
@@ -48,21 +50,19 @@ public class MessageEventImpl extends AbstractBuildEvent implements MessageEvent
         super.setDescription(description);
     }
 
-    
     @Override
     public Kind getKind() {
         return myKind;
     }
 
-    
     @Override
     public NotificationGroup getGroup() {
         return myGroup;
     }
 
     @Override
-    public @Nullable Navigatable getNavigatable(Project project) {
-        return myNavigatable;
+    public @Nullable Navigable getNavigable(Project project) {
+        return myNavigable;
     }
 
     @Override
@@ -89,7 +89,10 @@ public class MessageEventImpl extends AbstractBuildEvent implements MessageEvent
             return false;
         }
         MessageEventImpl event = (MessageEventImpl) o;
-        return Objects.equals(getMessage(), event.getMessage()) && Objects.equals(getDescription(), event.getDescription()) && Objects.equals(myGroup, event.myGroup);
+        return Objects.equals(getMessage(), event.getMessage()) && Objects.equals(
+            getDescription(),
+            event.getDescription()
+        ) && Objects.equals(myGroup, event.myGroup);
     }
 
     @Override

--- a/modules/base/compiler-api/src/main/java/consulo/compiler/CompileContext.java
+++ b/modules/base/compiler-api/src/main/java/consulo/compiler/CompileContext.java
@@ -21,11 +21,10 @@ import consulo.compiler.scope.CompileScope;
 import consulo.content.ContentFolderTypeProvider;
 import consulo.localize.LocalizeValue;
 import consulo.module.Module;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.util.dataholder.UserDataHolder;
 import consulo.virtualFileSystem.VirtualFile;
-
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -47,15 +46,15 @@ public interface CompileContext extends UserDataHolder {
     void addMessage(CompilerMessageCategory category, String message, @Nullable String url, int lineNum, int columnNum);
 
     /**
-     * Allows to add a message to be shown in Compiler message view, with a specified Navigatable
+     * Allows to add a message to be shown in Compiler message view, with a specified Navigable
      * that is used to navigate to the error location.
      *
-     * @param category    the category of a message (information, error, warning).
-     * @param message     the text of the message.
-     * @param url         a url to the file to which the message applies, null if not available.
-     * @param lineNum     a line number, -1 if not available.
-     * @param columnNum   a column number, -1 if not available.
-     * @param navigatable the navigatable pointing to the error location.
+     * @param category  the category of a message (information, error, warning).
+     * @param message   the text of the message.
+     * @param url       a url to the file to which the message applies, null if not available.
+     * @param lineNum   a line number, -1 if not available.
+     * @param columnNum a column number, -1 if not available.
+     * @param navigable the navigable pointing to the error location.
      */
     @Deprecated
     @DeprecationInfo("Use newError/newWarning/newInfo()...add()")
@@ -65,7 +64,7 @@ public interface CompileContext extends UserDataHolder {
         @Nullable String url,
         int lineNum,
         int columnNum,
-        Navigatable navigatable
+        Navigable navigable
     );
 
     /**

--- a/modules/base/compiler-api/src/main/java/consulo/compiler/CompileContextExDelegate.java
+++ b/modules/base/compiler-api/src/main/java/consulo/compiler/CompileContextExDelegate.java
@@ -20,11 +20,10 @@ import consulo.compiler.scope.CompileScope;
 import consulo.content.ContentFolderTypeProvider;
 import consulo.localize.LocalizeValue;
 import consulo.module.Module;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.util.dataholder.Key;
 import consulo.virtualFileSystem.VirtualFile;
-
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
@@ -96,9 +95,9 @@ public class CompileContextExDelegate implements CompileContextEx {
         @Nullable String url,
         int lineNum,
         int columnNum,
-        Navigatable navigatable
+        Navigable navigable
     ) {
-        myDelegate.addMessage(category, message, url, lineNum, columnNum, navigatable);
+        myDelegate.addMessage(category, message, url, lineNum, columnNum, navigable);
     }
 
     @Override
@@ -106,7 +105,6 @@ public class CompileContextExDelegate implements CompileContextEx {
         return myDelegate.getMessageCount(category);
     }
 
-    
     @Override
     public ProgressIndicator getProgressIndicator() {
         return myDelegate.getProgressIndicator();

--- a/modules/base/compiler-api/src/main/java/consulo/compiler/CompilerMessage.java
+++ b/modules/base/compiler-api/src/main/java/consulo/compiler/CompilerMessage.java
@@ -15,6 +15,8 @@
  */
 package consulo.compiler;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.virtualFileSystem.VirtualFile;
 import consulo.navigation.Navigatable;
 
@@ -49,11 +51,18 @@ public interface CompilerMessage {
     String getMessage();
 
     /**
-     * Returns the navigatable object allowing to navigate to the message source.
+     * Returns the navigable object allowing to navigate to the message source.
      *
      * @return the instance.
      */
-    @Nullable Navigatable getNavigatable();
+    @Nullable Navigable getNavigable();
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable() {
+        return (Navigatable) getNavigable();
+    }
 
     /**
      * Returns the file to which the message applies.

--- a/modules/base/compiler-api/src/main/java/consulo/compiler/ProblemsView.java
+++ b/modules/base/compiler-api/src/main/java/consulo/compiler/ProblemsView.java
@@ -18,16 +18,15 @@ package consulo.compiler;
 import consulo.annotation.DeprecationInfo;
 import consulo.annotation.component.ComponentScope;
 import consulo.annotation.component.ServiceAPI;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
-import consulo.ui.ex.toolWindow.ToolWindow;
 import consulo.project.ui.wm.ToolWindowId;
 import consulo.project.ui.wm.ToolWindowManager;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.content.Content;
 import consulo.ui.ex.content.ContentManager;
+import consulo.ui.ex.toolWindow.ToolWindow;
 import consulo.util.collection.ArrayUtil;
-
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -76,7 +75,7 @@ public abstract class ProblemsView {
         int type,
         String[] text,
         @Nullable String groupName,
-        @Nullable Navigatable navigatable,
+        @Nullable Navigable navigable,
         @Nullable String exportTextPrefix,
         @Nullable String rendererTextPrefix
     );

--- a/modules/base/compiler-impl/src/main/java/consulo/compiler/impl/internal/CompileContextImpl.java
+++ b/modules/base/compiler-impl/src/main/java/consulo/compiler/impl/internal/CompileContextImpl.java
@@ -25,14 +25,13 @@ import consulo.language.content.LanguageContentFolderScopes;
 import consulo.language.content.ProductionContentFolderTypeProvider;
 import consulo.language.content.TestContentFolderTypeProvider;
 import consulo.language.psi.stub.FileBasedIndex;
-import consulo.localize.LocalizeValue;
 import consulo.logging.Logger;
 import consulo.module.Module;
 import consulo.module.ModuleManager;
 import consulo.module.content.ModuleRootManager;
 import consulo.module.content.ProjectFileIndex;
 import consulo.module.content.ProjectRootManager;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.content.TestSourcesFilter;
 import consulo.util.collection.OrderedSet;
@@ -193,10 +192,10 @@ public class CompileContextImpl extends UserDataHolderBase implements CompileCon
         String url,
         int lineNum,
         int columnNum,
-        Navigatable navigatable
+        Navigable navigable
     ) {
         CompilerMessageImpl msg =
-            new CompilerMessageImpl(myProject, category, message, findPresentableFileForMessage(url), lineNum, columnNum, navigatable);
+            new CompilerMessageImpl(myProject, category, message, findPresentableFileForMessage(url), lineNum, columnNum, navigable);
         addMessage(msg);
     }
 

--- a/modules/base/compiler-impl/src/main/java/consulo/compiler/impl/internal/CompilerMessageImpl.java
+++ b/modules/base/compiler-impl/src/main/java/consulo/compiler/impl/internal/CompilerMessageImpl.java
@@ -18,7 +18,7 @@ package consulo.compiler.impl.internal;
 import consulo.compiler.CompilerMessage;
 import consulo.compiler.CompilerMessageCategory;
 import consulo.compiler.localize.CompilerLocalize;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.project.Project;
 import consulo.virtualFileSystem.VirtualFile;
@@ -27,11 +27,10 @@ import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 public final class CompilerMessageImpl implements CompilerMessage {
-    
     private final Project myProject;
     
     private final CompilerMessageCategory myCategory;
-    private @Nullable Navigatable myNavigatable;
+    private @Nullable Navigable myNavigable;
     
     private final String myMessage;
     private final @Nullable VirtualFile myFile;
@@ -49,40 +48,38 @@ public final class CompilerMessageImpl implements CompilerMessage {
         @Nullable VirtualFile file,
         int row,
         int column,
-        @Nullable Navigatable navigatable
+        @Nullable Navigable navigable
     ) {
         myProject = project;
         myCategory = category;
-        myNavigatable = navigatable;
+        myNavigable = navigable;
         myMessage = message == null ? "" : message;
         myRow = row;
         myColumn = column;
         myFile = file;
     }
 
-    
     @Override
     public CompilerMessageCategory getCategory() {
         return myCategory;
     }
 
-    
     @Override
     public String getMessage() {
         return myMessage;
     }
 
     @Override
-    public @Nullable Navigatable getNavigatable() {
-        if (myNavigatable != null) {
-            return myNavigatable;
+    public @Nullable Navigable getNavigable() {
+        if (myNavigable != null) {
+            return myNavigable;
         }
         VirtualFile virtualFile = getVirtualFile();
         if (virtualFile != null && virtualFile.isValid()) {
             int line = getLine() - 1; // editor lines are zero-based
             if (line >= 0) {
                 OpenFileDescriptorFactory factory = OpenFileDescriptorFactory.getInstance(myProject);
-                return myNavigatable = factory.newBuilder(virtualFile).line(line).column(Math.max(0, getColumn() - 1)).build();
+                return myNavigable = factory.newBuilder(virtualFile).line(line).column(Math.max(0, getColumn() - 1)).build();
             }
         }
         return null;

--- a/modules/base/compiler-impl/src/main/java/consulo/compiler/impl/internal/DummyCompileContext.java
+++ b/modules/base/compiler-impl/src/main/java/consulo/compiler/impl/internal/DummyCompileContext.java
@@ -23,7 +23,7 @@ import consulo.compiler.scope.CompileScope;
 import consulo.content.ContentFolderTypeProvider;
 import consulo.language.content.ProductionContentFolderTypeProvider;
 import consulo.module.Module;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.util.dataholder.Key;
 import consulo.virtualFileSystem.VirtualFile;
@@ -57,7 +57,7 @@ public class DummyCompileContext implements CompileContext {
         @Nullable String url,
         int lineNum,
         int columnNum,
-        Navigatable navigatable
+        Navigable navigable
     ) {
     }
 

--- a/modules/base/diff-api/src/main/java/consulo/diff/DiffDataKeys.java
+++ b/modules/base/diff-api/src/main/java/consulo/diff/DiffDataKeys.java
@@ -15,6 +15,7 @@
  */
 package consulo.diff;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.codeEditor.Editor;
 import consulo.diff.content.DiffContent;
 import consulo.diff.merge.MergeTool;
@@ -24,19 +25,29 @@ import consulo.navigation.Navigatable;
 import consulo.util.dataholder.Key;
 
 public interface DiffDataKeys {
-  Key<Navigatable> NAVIGATABLE = Key.create("diff_navigatable");
-  Key<Navigatable[]> NAVIGATABLE_ARRAY = Key.create("diff_navigatable_array");
+    Key<Navigatable> NAVIGABLE = Key.create("diff_navigatable");
+    Key<Navigatable[]> NAVIGABLE_ARRAY = Key.create("diff_navigatable_array");
 
-  Key<Editor> CURRENT_EDITOR = Key.create("diff_current_editor");
-  Key<DiffContent> CURRENT_CONTENT = Key.create("diff_current_content");
-  Key<LineRange> CURRENT_CHANGE_RANGE = Key.create("diff_current_change_range");
+    @Deprecated
+    @DeprecationInfo("Use #NAVIGABLE with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    Key<Navigatable> NAVIGATABLE = NAVIGABLE;
 
-  Key<DiffRequest> DIFF_REQUEST = Key.create("diff_request");
-  Key<DiffContext> DIFF_CONTEXT = Key.create("diff_context");
-  Key<FrameDiffTool.DiffViewer> DIFF_VIEWER = Key.create("diff_frame_viewer");
-  Key<FrameDiffTool.DiffViewer> WRAPPING_DIFF_VIEWER = Key.create("main_diff_frame_viewer"); // if DiffViewerWrapper is used
+    @Deprecated
+    @DeprecationInfo("Use #NAVIGABLE_ARRAY with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    Key<Navigatable[]> NAVIGATABLE_ARRAY = NAVIGABLE_ARRAY;
 
-  Key<MergeTool.MergeViewer> MERGE_VIEWER = Key.create("merge_viewer");
+    Key<Editor> CURRENT_EDITOR = Key.create("diff_current_editor");
+    Key<DiffContent> CURRENT_CONTENT = Key.create("diff_current_content");
+    Key<LineRange> CURRENT_CHANGE_RANGE = Key.create("diff_current_change_range");
 
-  Key<PrevNextDifferenceIterable> PREV_NEXT_DIFFERENCE_ITERABLE = Key.create("prev_next_difference_iterable");
+    Key<DiffRequest> DIFF_REQUEST = Key.create("diff_request");
+    Key<DiffContext> DIFF_CONTEXT = Key.create("diff_context");
+    Key<FrameDiffTool.DiffViewer> DIFF_VIEWER = Key.create("diff_frame_viewer");
+    Key<FrameDiffTool.DiffViewer> WRAPPING_DIFF_VIEWER = Key.create("main_diff_frame_viewer"); // if DiffViewerWrapper is used
+
+    Key<MergeTool.MergeViewer> MERGE_VIEWER = Key.create("merge_viewer");
+
+    Key<PrevNextDifferenceIterable> PREV_NEXT_DIFFERENCE_ITERABLE = Key.create("prev_next_difference_iterable");
 }

--- a/modules/base/diff-api/src/main/java/consulo/diff/content/DiffContent.java
+++ b/modules/base/diff-api/src/main/java/consulo/diff/content/DiffContent.java
@@ -15,7 +15,9 @@
  */
 package consulo.diff.content;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.diff.request.DiffRequest;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptor;
 import consulo.navigation.Navigatable;
 import consulo.ui.annotation.RequiredUIAccess;
@@ -31,21 +33,29 @@ import org.jspecify.annotations.Nullable;
  * @see DiffRequest
  */
 public interface DiffContent extends UserDataHolder {
-  @Nullable FileType getContentType();
+    @Nullable
+    FileType getContentType();
 
-  /**
-   * Provides a way to open related content in editor
-   */
-  @Nullable Navigatable getNavigatable();
+    /**
+     * Provides a way to open related content in editor
+     */
+    @Nullable Navigable getNavigable();
 
-  /**
-   * @see DiffRequest#onAssigned(boolean)
-   */
-  @RequiredUIAccess
-  void onAssigned(boolean isAssigned);
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable() {
+        return (Navigatable) getNavigable();
+    }
 
-  @Deprecated
-  default @Nullable OpenFileDescriptor getOpenFileDescriptor() {
-    return ObjectUtil.tryCast(getNavigatable(), OpenFileDescriptor.class);
-  }
+    /**
+     * @see DiffRequest#onAssigned(boolean)
+     */
+    @RequiredUIAccess
+    void onAssigned(boolean isAssigned);
+
+    @Deprecated
+    default @Nullable OpenFileDescriptor getOpenFileDescriptor() {
+        return ObjectUtil.tryCast(getNavigable(), OpenFileDescriptor.class);
+    }
 }

--- a/modules/base/diff-api/src/main/java/consulo/diff/content/DiffContentBase.java
+++ b/modules/base/diff-api/src/main/java/consulo/diff/content/DiffContentBase.java
@@ -15,20 +15,19 @@
  */
 package consulo.diff.content;
 
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.util.dataholder.UserDataHolderBase;
-
 import org.jspecify.annotations.Nullable;
 
 public abstract class DiffContentBase extends UserDataHolderBase implements DiffContent {
-  @Override
-  public @Nullable Navigatable getNavigatable() {
-    return null;
-  }
+    @Override
+    public @Nullable Navigable getNavigable() {
+        return null;
+    }
 
-  @Override
-  @RequiredUIAccess
-  public void onAssigned(boolean isAssigned) {
-  }
+    @Override
+    @RequiredUIAccess
+    public void onAssigned(boolean isAssigned) {
+    }
 }

--- a/modules/base/diff-api/src/main/java/consulo/diff/content/DocumentContent.java
+++ b/modules/base/diff-api/src/main/java/consulo/diff/content/DocumentContent.java
@@ -15,62 +15,71 @@
  */
 package consulo.diff.content;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.diff.util.LineCol;
 import consulo.document.Document;
-import consulo.navigation.OpenFileDescriptor;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
+import consulo.navigation.OpenFileDescriptor;
 import consulo.platform.LineSeparator;
 import consulo.util.lang.ObjectUtil;
 import consulo.virtualFileSystem.VirtualFile;
-
 import org.jspecify.annotations.Nullable;
+
 import java.nio.charset.Charset;
 
 public interface DocumentContent extends DiffContent {
-  /**
-   * Represents this content as Document
-   */
-  Document getDocument();
+    /**
+     * Represents this content as Document
+     */
+    Document getDocument();
 
-  /**
-   * This file could be used for better syntax highlighting.
-   * Some file types can't be highlighted properly depending only on their FileType (ex: SQL dialects, PHP templates).
-   */
-  default @Nullable VirtualFile getHighlightFile() {
-    return null;
-  }
+    /**
+     * This file could be used for better syntax highlighting.
+     * Some file types can't be highlighted properly depending only on their FileType (ex: SQL dialects, PHP templates).
+     */
+    default @Nullable VirtualFile getHighlightFile() {
+        return null;
+    }
 
-  /**
-   * Provides a way to open given text place in editor
-   */
-  default @Nullable Navigatable getNavigatable(LineCol position) {
-    return null;
-  }
+    /**
+     * Provides a way to open given text place in editor
+     */
+    default @Nullable Navigable getNavigable(LineCol position) {
+        return null;
+    }
 
-  /**
-   * @return original file line separator
-   */
-  default @Nullable LineSeparator getLineSeparator() {
-    return null;
-  }
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable(LineCol position) {
+        return (Navigatable) getNavigable(position);
+    }
 
-  /**
-   * @return original file charset
-   */
-  default @Nullable Charset getCharset() {
-    return null;
-  }
+    /**
+     * @return original file line separator
+     */
+    default @Nullable LineSeparator getLineSeparator() {
+        return null;
+    }
 
-  /**
-   * @return original file byte order mark
-   */
-  default @Nullable Boolean hasBom() {
-    return null;
-  }
+    /**
+     * @return original file charset
+     */
+    default @Nullable Charset getCharset() {
+        return null;
+    }
 
-  @Deprecated
-  default @Nullable OpenFileDescriptor getOpenFileDescriptor(int offset) {
-    LineCol position = LineCol.fromOffset(getDocument(), offset);
-    return ObjectUtil.tryCast(getNavigatable(position), OpenFileDescriptor.class);
-  }
+    /**
+     * @return original file byte order mark
+     */
+    default @Nullable Boolean hasBom() {
+        return null;
+    }
+
+    @Deprecated
+    default @Nullable OpenFileDescriptor getOpenFileDescriptor(int offset) {
+        LineCol position = LineCol.fromOffset(getDocument(), offset);
+        return ObjectUtil.tryCast(getNavigable(position), OpenFileDescriptor.class);
+    }
 }

--- a/modules/base/diff-api/src/main/java/consulo/diff/dir/DiffElement.java
+++ b/modules/base/diff-api/src/main/java/consulo/diff/dir/DiffElement.java
@@ -15,12 +15,14 @@
  */
 package consulo.diff.dir;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.application.progress.ProgressIndicator;
 import consulo.component.ProcessCanceledException;
 import consulo.diff.DiffContentFactory;
 import consulo.diff.chain.DiffRequestProducer;
 import consulo.diff.chain.DiffRequestProducerException;
 import consulo.diff.content.DiffContent;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.ui.image.Image;
@@ -38,113 +40,122 @@ import java.util.concurrent.Callable;
  * @author Konstantin Bulenkov
  */
 public abstract class DiffElement<T> {
-  public static final DiffElement[] EMPTY_ARRAY = new DiffElement[0];
+    public static final DiffElement[] EMPTY_ARRAY = new DiffElement[0];
 
-  public abstract String getPath();
+    public abstract String getPath();
 
-  
-  public abstract String getName();
+    public abstract String getName();
 
-  public String getPresentablePath() {
-    return getName();
-  }
-
-  public abstract long getSize();
-
-  public abstract long getTimeStamp();
-
-  public FileType getFileType() {
-    return FileTypeRegistry.getInstance().getFileTypeByFileName(getName());
-  }
-
-  public abstract boolean isContainer();
-
-  public abstract DiffElement[] getChildren() throws IOException;
-
-  public @Nullable Navigatable getNavigatable(@Nullable Project project) {
-    return null;
-  }
-
-  /**
-   * Returns content data as byte array. Can be null, if element for example is a container
-   * @return content byte array
-   * @throws IOException when reading
-   */
-  public abstract @Nullable byte[] getContent() throws IOException;
-
-  
-  public Charset getCharset() {
-    return EncodingManager.getInstance().getDefaultCharset();
-  }
-
-  public abstract T getValue();
-
-  public String getSeparator() {
-    return "/";
-  }
-
-  public @Nullable Image getIcon() {
-    return null;
-  }
-
-  /**
-   * Called in background thread without ReadLock OR in EDT
-   *
-   * @see DiffRequestProducer#process
-   */
-  public DiffContent createDiffContent(@Nullable Project project, ProgressIndicator indicator)
-          throws DiffRequestProducerException, ProcessCanceledException {
-    try {
-      T src = getValue();
-      if (src instanceof VirtualFile) {
-        return DiffContentFactory.getInstance().create(project, (VirtualFile)src);
-      }
-
-      byte[] content = getContent();
-      if (content == null) throw new DiffRequestProducerException("Can't get content");
-
-      return DiffContentFactory.getInstance().create(new String(content, getCharset()), getFileType());
+    public String getPresentablePath() {
+        return getName();
     }
-    catch (IOException e) {
-      throw new DiffRequestProducerException(e);
+
+    public abstract long getSize();
+
+    public abstract long getTimeStamp();
+
+    public FileType getFileType() {
+        return FileTypeRegistry.getInstance().getFileTypeByFileName(getName());
     }
-  }
 
-  public @Nullable Callable<DiffElement<T>> getElementChooser(Project project) {
-    return null;
-  }
+    public abstract boolean isContainer();
 
-  /**
-   * Defines is it possible to perform such operations as copy or delete through Diff Panel
-   *
-   * @return <code>true</code> if copy, delete, etc operations are allowed,
-   *        <code>false</code> otherwise
-   */
-  public boolean isOperationsEnabled() {
-    return false;
-  }
+    public abstract DiffElement[] getChildren() throws IOException;
 
-  /**
-   * Copies element to the container.
-   *
-   * @param container file directory or other container
-   * @param relativePath relative path from root
-   * @return <code>true</code> if coping was completed successfully,
-   *        <code>false</code> otherwise
-   */
-  public @Nullable DiffElement<?> copyTo(DiffElement<T> container, String relativePath) {
-    return null;
-  }
+    public @Nullable Navigable getNavigable(@Nullable Project project) {
+        return null;
+    }
 
-  /**
-   * Deletes element
-   * @return <code>true</code> if deletion was completed successfully,
-   *        <code>false</code> otherwise
-   */
-  public boolean delete() {
-    return false;
-  }
+    @Deprecated
+    @DeprecationInfo("Use #NAVIGABLE_ARRAY with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public final @Nullable Navigatable getNavigatable(@Nullable Project project) {
+        return (Navigatable) getNavigable(project);
+    }
 
-  public void refresh(boolean userInitiated) throws IOException{
-  }
+    /**
+     * Returns content data as byte array. Can be null, if element for example is a container
+     *
+     * @return content byte array
+     * @throws IOException when reading
+     */
+    public abstract byte @Nullable [] getContent() throws IOException;
+
+    public Charset getCharset() {
+        return EncodingManager.getInstance().getDefaultCharset();
+    }
+
+    public abstract T getValue();
+
+    public String getSeparator() {
+        return "/";
+    }
+
+    public @Nullable Image getIcon() {
+        return null;
+    }
+
+    /**
+     * Called in background thread without ReadLock OR in EDT
+     *
+     * @see DiffRequestProducer#process
+     */
+    public DiffContent createDiffContent(@Nullable Project project, ProgressIndicator indicator)
+        throws DiffRequestProducerException, ProcessCanceledException {
+        try {
+            T src = getValue();
+            if (src instanceof VirtualFile) {
+                return DiffContentFactory.getInstance().create(project, (VirtualFile) src);
+            }
+
+            byte[] content = getContent();
+            if (content == null) {
+                throw new DiffRequestProducerException("Can't get content");
+            }
+
+            return DiffContentFactory.getInstance().create(new String(content, getCharset()), getFileType());
+        }
+        catch (IOException e) {
+            throw new DiffRequestProducerException(e);
+        }
+    }
+
+    public @Nullable Callable<DiffElement<T>> getElementChooser(Project project) {
+        return null;
+    }
+
+    /**
+     * Defines is it possible to perform such operations as copy or delete through Diff Panel
+     *
+     * @return <code>true</code> if copy, delete, etc operations are allowed,
+     * <code>false</code> otherwise
+     */
+    public boolean isOperationsEnabled() {
+        return false;
+    }
+
+    /**
+     * Copies element to the container.
+     *
+     * @param container    file directory or other container
+     * @param relativePath relative path from root
+     * @return <code>true</code> if coping was completed successfully,
+     * <code>false</code> otherwise
+     */
+    public @Nullable DiffElement<?> copyTo(DiffElement<T> container, String relativePath) {
+        return null;
+    }
+
+    /**
+     * Deletes element
+     *
+     * @return <code>true</code> if deletion was completed successfully,
+     * <code>false</code> otherwise
+     */
+    public boolean delete() {
+        return false;
+    }
+
+    public void refresh(boolean userInitiated) throws IOException {
+    }
 }

--- a/modules/base/diff-api/src/main/java/consulo/diff/dir/VirtualFileDiffElement.java
+++ b/modules/base/diff-api/src/main/java/consulo/diff/dir/VirtualFileDiffElement.java
@@ -15,22 +15,24 @@
  */
 package consulo.diff.dir;
 
-import consulo.application.AllIcons;
-import consulo.application.ApplicationManager;
+import consulo.annotation.access.RequiredWriteAction;
+import consulo.application.Application;
 import consulo.application.WriteAction;
 import consulo.application.progress.ProgressManager;
-import consulo.application.util.function.ThrowableComputable;
 import consulo.document.Document;
 import consulo.document.FileDocumentManager;
 import consulo.fileChooser.FileChooserDescriptor;
 import consulo.fileChooser.IdeaFileChooser;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptorFactory;
+import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.project.Project;
 import consulo.ui.ModalityState;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.image.Image;
 import consulo.util.io.FilePermissionCopier;
 import consulo.util.io.FileUtil;
+import consulo.util.lang.function.ThrowableSupplier;
 import consulo.virtualFileSystem.*;
 import consulo.virtualFileSystem.fileType.FileTypeRegistry;
 import consulo.virtualFileSystem.util.VirtualFileUtil;
@@ -46,160 +48,159 @@ import java.util.concurrent.Callable;
  * @author Konstantin Bulenkov
  */
 public class VirtualFileDiffElement extends DiffElement<VirtualFile> {
-  private final VirtualFile myFile;
+    private final VirtualFile myFile;
 
-  public VirtualFileDiffElement(VirtualFile file) {
-    myFile = file;
-  }
-
-  @Override
-  public String getPath() {
-    return myFile.getPresentableUrl();
-  }
-
-  
-  @Override
-  public String getName() {
-    return myFile.getName();
-  }
-
-  @Override
-  public String getPresentablePath() {
-    return getPath();
-  }
-
-  @Override
-  public long getSize() {
-    return myFile.getLength();
-  }
-
-  @Override
-  public long getTimeStamp() {
-    return myFile.getTimeStamp();
-  }
-
-  @Override
-  public boolean isContainer() {
-    return myFile.isDirectory();
-  }
-
-  @Override
-  public @Nullable Navigatable getNavigatable(@Nullable Project project) {
-    if (project == null || project.isDefault() || !myFile.isValid()) return null;
-    return OpenFileDescriptorFactory.getInstance(project).newBuilder(myFile).build();
-  }
-
-  @Override
-  public VirtualFileDiffElement[] getChildren() {
-    if (myFile.is(VFileProperty.SYMLINK)) {
-      return new VirtualFileDiffElement[0];
+    public VirtualFileDiffElement(VirtualFile file) {
+        myFile = file;
     }
-    List<VirtualFileDiffElement> elements = new ArrayList<>();
-    for (VirtualFile file : myFile.getRequiredChildren()) {
-      if (!FileTypeRegistry.getInstance().isFileIgnored(file) && file.isValid()) {
-        elements.add(new VirtualFileDiffElement(file));
-      }
+
+    @Override
+    public String getPath() {
+        return myFile.getPresentableUrl();
     }
-    return elements.toArray(new VirtualFileDiffElement[elements.size()]);
-  }
 
-  @Override
-  public @Nullable byte[] getContent() throws IOException {
-    return ApplicationManager.getApplication().runReadAction(new ThrowableComputable<byte[], IOException>() {
-      @Override
-      public byte[] compute() throws IOException {
-        return myFile.contentsToByteArray();
-      }
-    });
-  }
-
-  @Override
-  public VirtualFile getValue() {
-    return myFile;
-  }
-
-  @Override
-  public Image getIcon() {
-    return isContainer() ? AllIcons.Nodes.Folder : VirtualFilePresentation.getIcon(myFile);
-  }
-
-  @Override
-  public Callable<DiffElement<VirtualFile>> getElementChooser(Project project) {
-    return () -> {
-      FileChooserDescriptor descriptor = getChooserDescriptor();
-      VirtualFile[] result = IdeaFileChooser.chooseFiles(descriptor, project, getValue());
-      return result.length == 1 ? createElement(result[0]) : null;
-    };
-  }
-
-  protected @Nullable VirtualFileDiffElement createElement(VirtualFile file) {
-    return new VirtualFileDiffElement(file);
-  }
-
-  protected FileChooserDescriptor getChooserDescriptor() {
-    return new FileChooserDescriptor(false, true, false, false, false, false);
-  }
-
-  @Override
-  public boolean isOperationsEnabled() {
-    return myFile.getFileSystem() instanceof LocalFileSystem;
-  }
-
-  @Override
-  public VirtualFileDiffElement copyTo(DiffElement<VirtualFile> container, String relativePath) {
-    try {
-      File src = new File(myFile.getPath());
-      File trg = new File(container.getValue().getPath() + relativePath + src.getName());
-      FileUtil.copy(src, trg, FilePermissionCopier.BY_NIO2);
-      VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(trg);
-      if (virtualFile != null) {
-        return new VirtualFileDiffElement(virtualFile);
-      }
+    @Override
+    public String getName() {
+        return myFile.getName();
     }
-    catch (IOException e) {//
-    }
-    return null;
-  }
 
-  @Override
-  public boolean delete() {
-    try {
-      myFile.delete(this);
+    @Override
+    public String getPresentablePath() {
+        return getPath();
     }
-    catch (IOException e) {
-      return false;
+
+    @Override
+    public long getSize() {
+        return myFile.getLength();
     }
-    return true;
-  }
 
-  @Override
-  public void refresh(boolean userInitiated) {
-    refreshFile(userInitiated, myFile);
-  }
+    @Override
+    public long getTimeStamp() {
+        return myFile.getTimeStamp();
+    }
 
-  public static void refreshFile(boolean userInitiated, VirtualFile virtualFile) {
-    if (userInitiated) {
-      List<Document> docsToSave = new ArrayList<>();
-      FileDocumentManager manager = FileDocumentManager.getInstance();
-      for (Document document : manager.getUnsavedDocuments()) {
-        VirtualFile file = manager.getFile(document);
-        if (file != null && VirtualFileUtil.isAncestor(virtualFile, file, false)) {
-          docsToSave.add(document);
+    @Override
+    public boolean isContainer() {
+        return myFile.isDirectory();
+    }
+
+    @Override
+    public @Nullable Navigable getNavigable(@Nullable Project project) {
+        if (project == null || project.isDefault() || !myFile.isValid()) {
+            return null;
         }
-      }
-
-      if (!docsToSave.isEmpty()) {
-        WriteAction.run(() -> {
-          for (Document document : docsToSave) {
-            manager.saveDocument(document);
-          }
-        });
-      }
-
-      ModalityState modalityState = ProgressManager.getInstance().getProgressIndicator().getModalityState();
-
-      VirtualFileUtil.markDirty(true, true, virtualFile);
-      RefreshQueue.getInstance().refresh(false, true, null, modalityState, virtualFile);
+        return OpenFileDescriptorFactory.getInstance(project).newBuilder(myFile).build();
     }
-  }
+
+    @Override
+    public VirtualFileDiffElement[] getChildren() {
+        if (myFile.is(VFileProperty.SYMLINK)) {
+            return new VirtualFileDiffElement[0];
+        }
+        List<VirtualFileDiffElement> elements = new ArrayList<>();
+        for (VirtualFile file : myFile.getRequiredChildren()) {
+            if (!FileTypeRegistry.getInstance().isFileIgnored(file) && file.isValid()) {
+                elements.add(new VirtualFileDiffElement(file));
+            }
+        }
+        return elements.toArray(new VirtualFileDiffElement[elements.size()]);
+    }
+
+    @Override
+    public byte @Nullable [] getContent() throws IOException {
+        return Application.get().runReadAction((ThrowableSupplier<byte[], IOException>) () -> myFile.contentsToByteArray());
+    }
+
+    @Override
+    public VirtualFile getValue() {
+        return myFile;
+    }
+
+    @Override
+    public Image getIcon() {
+        return isContainer() ? PlatformIconGroup.nodesFolder() : VirtualFilePresentation.getIcon(myFile);
+    }
+
+    @Override
+    public Callable<DiffElement<VirtualFile>> getElementChooser(Project project) {
+        return () -> {
+            FileChooserDescriptor descriptor = getChooserDescriptor();
+            VirtualFile[] result = IdeaFileChooser.chooseFiles(descriptor, project, getValue());
+            return result.length == 1 ? createElement(result[0]) : null;
+        };
+    }
+
+    protected @Nullable VirtualFileDiffElement createElement(VirtualFile file) {
+        return new VirtualFileDiffElement(file);
+    }
+
+    protected FileChooserDescriptor getChooserDescriptor() {
+        return new FileChooserDescriptor(false, true, false, false, false, false);
+    }
+
+    @Override
+    public boolean isOperationsEnabled() {
+        return myFile.getFileSystem() instanceof LocalFileSystem;
+    }
+
+    @Override
+    public VirtualFileDiffElement copyTo(DiffElement<VirtualFile> container, String relativePath) {
+        try {
+            File src = new File(myFile.getPath());
+            File trg = new File(container.getValue().getPath() + relativePath + src.getName());
+            FileUtil.copy(src, trg, FilePermissionCopier.BY_NIO2);
+            VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(trg);
+            if (virtualFile != null) {
+                return new VirtualFileDiffElement(virtualFile);
+            }
+        }
+        catch (IOException e) {//
+        }
+        return null;
+    }
+
+    @Override
+    @RequiredWriteAction
+    public boolean delete() {
+        try {
+            myFile.delete(this);
+        }
+        catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    @RequiredUIAccess
+    public void refresh(boolean userInitiated) {
+        refreshFile(userInitiated, myFile);
+    }
+
+    @RequiredUIAccess
+    public static void refreshFile(boolean userInitiated, VirtualFile virtualFile) {
+        if (userInitiated) {
+            List<Document> docsToSave = new ArrayList<>();
+            FileDocumentManager manager = FileDocumentManager.getInstance();
+            for (Document document : manager.getUnsavedDocuments()) {
+                VirtualFile file = manager.getFile(document);
+                if (file != null && VirtualFileUtil.isAncestor(virtualFile, file, false)) {
+                    docsToSave.add(document);
+                }
+            }
+
+            if (!docsToSave.isEmpty()) {
+                WriteAction.run(() -> {
+                    for (Document document : docsToSave) {
+                        manager.saveDocument(document);
+                    }
+                });
+            }
+
+            ModalityState modalityState = ProgressManager.getInstance().getProgressIndicator().getModalityState();
+
+            VirtualFileUtil.markDirty(true, true, virtualFile);
+            RefreshQueue.getInstance().refresh(false, true, null, modalityState, virtualFile);
+        }
+    }
 }

--- a/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/action/DocumentFragmentContent.java
+++ b/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/action/DocumentFragmentContent.java
@@ -23,9 +23,10 @@ import consulo.document.Document;
 import consulo.document.RangeMarker;
 import consulo.document.event.DocumentEvent;
 import consulo.document.util.TextRange;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.platform.LineSeparator;
 import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.undoRedo.UndoManager;
 import consulo.virtualFileSystem.VirtualFile;
 import consulo.virtualFileSystem.fileType.FileType;
@@ -37,144 +38,159 @@ import java.nio.charset.Charset;
  * Represents sub text of other content.
  */
 public class DocumentFragmentContent extends DiffContentBase implements DocumentContent {
-  // TODO: reuse DocumentWindow ?
+    // TODO: reuse DocumentWindow ?
 
-  
-  private final DocumentContent myOriginal;
-  
-  private final RangeMarker myRangeMarker;
 
-  
-  private final MyDocumentsSynchronizer mySynchronizer;
+    private final DocumentContent myOriginal;
 
-  private int myAssignments = 0;
-
-  public DocumentFragmentContent(@Nullable Project project, DocumentContent original, TextRange range) {
-    this(project, original, createRangeMarker(original.getDocument(), range));
-  }
-
-  public DocumentFragmentContent(@Nullable Project project, DocumentContent original, RangeMarker rangeMarker) {
-    myOriginal = original;
-    myRangeMarker = rangeMarker;
-
-    Document document1 = myOriginal.getDocument();
-
-    Document document2 = EditorFactory.getInstance().createDocument("");
-    document2.putUserData(UndoManager.ORIGINAL_DOCUMENT, document1);
-
-    mySynchronizer = new MyDocumentsSynchronizer(project, myRangeMarker, document1, document2);
-  }
-
-  
-  private static RangeMarker createRangeMarker(Document document, TextRange range) {
-    RangeMarker rangeMarker = document.createRangeMarker(range.getStartOffset(), range.getEndOffset(), true);
-    rangeMarker.setGreedyToLeft(true);
-    rangeMarker.setGreedyToRight(true);
-    return rangeMarker;
-  }
-
-  
-  @Override
-  public Document getDocument() {
-    return mySynchronizer.getDocument2();
-  }
-
-  @Override
-  public @Nullable VirtualFile getHighlightFile() {
-    return myOriginal.getHighlightFile();
-  }
-
-  @Override
-  public @Nullable Navigatable getNavigatable(LineCol position) {
-    if (!myRangeMarker.isValid()) return null;
-    int offset = position.toOffset(getDocument());
-    int originalOffset = offset + myRangeMarker.getStartOffset();
-    LineCol originalPosition = LineCol.fromOffset(myOriginal.getDocument(), originalOffset);
-    return myOriginal.getNavigatable(originalPosition);
-  }
-
-  @Override
-  public @Nullable LineSeparator getLineSeparator() {
-    return null;
-  }
-
-  @Override
-  public @Nullable Charset getCharset() {
-    return null;
-  }
-
-  @Override
-  public @Nullable FileType getContentType() {
-    return myOriginal.getContentType();
-  }
-
-  @Override
-  public @Nullable Navigatable getNavigatable() {
-    return getNavigatable(new LineCol(0));
-  }
-
-  @Override
-  public void onAssigned(boolean isAssigned) {
-    if (isAssigned) {
-      if (myAssignments == 0) mySynchronizer.startListen();
-      myAssignments++;
-    }
-    else {
-      myAssignments--;
-      if (myAssignments == 0) mySynchronizer.stopListen();
-    }
-    assert myAssignments >= 0;
-  }
-
-  private static class MyDocumentsSynchronizer extends DocumentsSynchronizer {
-    
     private final RangeMarker myRangeMarker;
 
-    public MyDocumentsSynchronizer(@Nullable Project project,
-                                   RangeMarker range,
-                                   Document document1,
-                                   Document document2) {
-      super(project, document1, document2);
-      myRangeMarker = range;
+
+    private final MyDocumentsSynchronizer mySynchronizer;
+
+    private int myAssignments = 0;
+
+    public DocumentFragmentContent(@Nullable Project project, DocumentContent original, TextRange range) {
+        this(project, original, createRangeMarker(original.getDocument(), range));
+    }
+
+    public DocumentFragmentContent(@Nullable Project project, DocumentContent original, RangeMarker rangeMarker) {
+        myOriginal = original;
+        myRangeMarker = rangeMarker;
+
+        Document document1 = myOriginal.getDocument();
+
+        Document document2 = EditorFactory.getInstance().createDocument("");
+        document2.putUserData(UndoManager.ORIGINAL_DOCUMENT, document1);
+
+        mySynchronizer = new MyDocumentsSynchronizer(project, myRangeMarker, document1, document2);
+    }
+
+
+    private static RangeMarker createRangeMarker(Document document, TextRange range) {
+        RangeMarker rangeMarker = document.createRangeMarker(range.getStartOffset(), range.getEndOffset(), true);
+        rangeMarker.setGreedyToLeft(true);
+        rangeMarker.setGreedyToRight(true);
+        return rangeMarker;
+    }
+
+
+    @Override
+    public Document getDocument() {
+        return mySynchronizer.getDocument2();
     }
 
     @Override
-    protected void onDocumentChanged1(DocumentEvent event) {
-      if (!myRangeMarker.isValid()) {
-        myDocument2.setReadOnly(false);
-        replaceString(myDocument2, 0, myDocument2.getTextLength(), "Invalid selection range");
-        myDocument2.setReadOnly(true);
-        return;
-      }
-      CharSequence newText = myDocument1.getCharsSequence().subSequence(myRangeMarker.getStartOffset(), myRangeMarker.getEndOffset());
-      replaceString(myDocument2, 0, myDocument2.getTextLength(), newText);
+    public @Nullable VirtualFile getHighlightFile() {
+        return myOriginal.getHighlightFile();
     }
 
     @Override
-    protected void onDocumentChanged2(DocumentEvent event) {
-      if (!myRangeMarker.isValid()) return;
-      if (!myDocument1.isWritable()) return;
-
-      CharSequence newText = event.getNewFragment();
-      int originalOffset = event.getOffset() + myRangeMarker.getStartOffset();
-      int originalEnd = originalOffset + event.getOldLength();
-      replaceString(myDocument1, originalOffset, originalEnd, newText);
+    public @Nullable Navigable getNavigable(LineCol position) {
+        if (!myRangeMarker.isValid()) {
+            return null;
+        }
+        int offset = position.toOffset(getDocument());
+        int originalOffset = offset + myRangeMarker.getStartOffset();
+        LineCol originalPosition = LineCol.fromOffset(myOriginal.getDocument(), originalOffset);
+        return myOriginal.getNavigable(originalPosition);
     }
 
     @Override
-    public void startListen() {
-      if (myRangeMarker.isValid()) {
-        myDocument2.setReadOnly(false);
-        CharSequence nexText = myDocument1.getCharsSequence().subSequence(myRangeMarker.getStartOffset(), myRangeMarker.getEndOffset());
-        replaceString(myDocument2, 0, myDocument2.getTextLength(), nexText);
-        myDocument2.setReadOnly(!myDocument1.isWritable());
-      }
-      else {
-        myDocument2.setReadOnly(false);
-        replaceString(myDocument2, 0, myDocument2.getTextLength(), "Invalid selection range");
-        myDocument2.setReadOnly(true);
-      }
-      super.startListen();
+    public @Nullable LineSeparator getLineSeparator() {
+        return null;
     }
-  }
+
+    @Override
+    public @Nullable Charset getCharset() {
+        return null;
+    }
+
+    @Override
+    public @Nullable FileType getContentType() {
+        return myOriginal.getContentType();
+    }
+
+    @Override
+    public @Nullable Navigable getNavigable() {
+        return getNavigable(new LineCol(0));
+    }
+
+    @Override
+    @RequiredUIAccess
+    public void onAssigned(boolean isAssigned) {
+        if (isAssigned) {
+            if (myAssignments == 0) {
+                mySynchronizer.startListen();
+            }
+            myAssignments++;
+        }
+        else {
+            myAssignments--;
+            if (myAssignments == 0) {
+                mySynchronizer.stopListen();
+            }
+        }
+        assert myAssignments >= 0;
+    }
+
+    private static class MyDocumentsSynchronizer extends DocumentsSynchronizer {
+        private final RangeMarker myRangeMarker;
+
+        public MyDocumentsSynchronizer(
+            @Nullable Project project,
+            RangeMarker range,
+            Document document1,
+            Document document2
+        ) {
+            super(project, document1, document2);
+            myRangeMarker = range;
+        }
+
+        @Override
+        @RequiredUIAccess
+        protected void onDocumentChanged1(DocumentEvent event) {
+            if (!myRangeMarker.isValid()) {
+                myDocument2.setReadOnly(false);
+                replaceString(myDocument2, 0, myDocument2.getTextLength(), "Invalid selection range");
+                myDocument2.setReadOnly(true);
+                return;
+            }
+            CharSequence newText = myDocument1.getCharsSequence().subSequence(myRangeMarker.getStartOffset(), myRangeMarker.getEndOffset());
+            replaceString(myDocument2, 0, myDocument2.getTextLength(), newText);
+        }
+
+        @Override
+        @RequiredUIAccess
+        protected void onDocumentChanged2(DocumentEvent event) {
+            if (!myRangeMarker.isValid()) {
+                return;
+            }
+            if (!myDocument1.isWritable()) {
+                return;
+            }
+
+            CharSequence newText = event.getNewFragment();
+            int originalOffset = event.getOffset() + myRangeMarker.getStartOffset();
+            int originalEnd = originalOffset + event.getOldLength();
+            replaceString(myDocument1, originalOffset, originalEnd, newText);
+        }
+
+        @Override
+        public void startListen() {
+            if (myRangeMarker.isValid()) {
+                myDocument2.setReadOnly(false);
+                CharSequence nexText =
+                    myDocument1.getCharsSequence().subSequence(myRangeMarker.getStartOffset(), myRangeMarker.getEndOffset());
+                replaceString(myDocument2, 0, myDocument2.getTextLength(), nexText);
+                myDocument2.setReadOnly(!myDocument1.isWritable());
+            }
+            else {
+                myDocument2.setReadOnly(false);
+                replaceString(myDocument2, 0, myDocument2.getTextLength(), "Invalid selection range");
+                myDocument2.setReadOnly(true);
+            }
+            super.startListen();
+        }
+    }
 }

--- a/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/DirectoryContentImpl.java
+++ b/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/DirectoryContentImpl.java
@@ -17,7 +17,7 @@ package consulo.diff.impl.internal.content;
 
 import consulo.diff.content.DiffContentBase;
 import consulo.diff.content.DirectoryContent;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.project.Project;
 import consulo.virtualFileSystem.VirtualFile;
@@ -25,30 +25,30 @@ import consulo.virtualFileSystem.fileType.FileType;
 import org.jspecify.annotations.Nullable;
 
 public class DirectoryContentImpl extends DiffContentBase implements DirectoryContent {
-  
-  private final VirtualFile myFile;
-  private final @Nullable Project myProject;
+    private final VirtualFile myFile;
+    private final @Nullable Project myProject;
 
-  public DirectoryContentImpl(@Nullable Project project, VirtualFile file) {
-    assert file.isValid() && file.isDirectory();
-    myProject = project;
-    myFile = file;
-  }
+    public DirectoryContentImpl(@Nullable Project project, VirtualFile file) {
+        assert file.isValid() && file.isDirectory();
+        myProject = project;
+        myFile = file;
+    }
 
-  @Override
-  public @Nullable Navigatable getNavigatable() {
-    if (myProject == null || myProject.isDefault() || !myFile.isValid()) return null;
-    return OpenFileDescriptorFactory.getInstance(myProject).newBuilder(myFile).build();
-  }
+    @Override
+    public @Nullable Navigable getNavigable() {
+        if (myProject == null || myProject.isDefault() || !myFile.isValid()) {
+            return null;
+        }
+        return OpenFileDescriptorFactory.getInstance(myProject).newBuilder(myFile).build();
+    }
 
-  
-  @Override
-  public VirtualFile getFile() {
-    return myFile;
-  }
+    @Override
+    public VirtualFile getFile() {
+        return myFile;
+    }
 
-  @Override
-  public @Nullable FileType getContentType() {
-    return null;
-  }
+    @Override
+    public @Nullable FileType getContentType() {
+        return null;
+    }
 }

--- a/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/DocumentContentImpl.java
+++ b/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/DocumentContentImpl.java
@@ -15,6 +15,7 @@
  */
 package consulo.diff.impl.internal.content;
 
+import consulo.annotation.access.RequiredReadAction;
 import consulo.application.util.diff.Diff;
 import consulo.application.util.diff.FilesTooBigForDiffException;
 import consulo.diff.content.DiffContentBase;
@@ -22,11 +23,13 @@ import consulo.diff.content.DocumentContent;
 import consulo.diff.util.LineCol;
 import consulo.document.Document;
 import consulo.document.FileDocumentManager;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.navigation.OpenFileDescriptor;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.platform.LineSeparator;
 import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.virtualFileSystem.VirtualFile;
 import consulo.virtualFileSystem.fileType.FileType;
 import org.jspecify.annotations.Nullable;
@@ -37,133 +40,140 @@ import java.nio.charset.Charset;
  * Allows to compare some text associated with document.
  */
 public class DocumentContentImpl extends DiffContentBase implements DocumentContent {
-  private final @Nullable Project myProject;
+    private final @Nullable Project myProject;
 
-  
-  private final Document myDocument;
-
-  private final @Nullable FileType myType;
-  private final @Nullable VirtualFile myHighlightFile;
-
-  private final @Nullable LineSeparator mySeparator;
-  private final @Nullable Charset myCharset;
-  private final @Nullable Boolean myBOM;
-
-  public DocumentContentImpl(Document document) {
-    this(null, document, null, null, null, null, null);
-  }
-
-  public DocumentContentImpl(@Nullable Project project,
-                             Document document,
-                             @Nullable FileType type,
-                             @Nullable VirtualFile highlightFile,
-                             @Nullable LineSeparator separator,
-                             @Nullable Charset charset,
-                             @Nullable Boolean bom) {
-    myProject = project;
-    myDocument = document;
-    myType = type;
-    myHighlightFile = highlightFile;
-    mySeparator = separator;
-    myCharset = charset;
-    myBOM = bom;
-  }
-
-  public @Nullable Project getProject() {
-    return myProject;
-  }
-
-  
-  @Override
-  public Document getDocument() {
-    return myDocument;
-  }
-
-  @Override
-  public @Nullable VirtualFile getHighlightFile() {
-    return myHighlightFile;
-  }
-
-  @Override
-  public @Nullable Navigatable getNavigatable(LineCol position) {
-    if (myProject == null || getHighlightFile() == null || !getHighlightFile().isValid()) return null;
-    return new MyNavigatable(myProject, getHighlightFile(), getDocument(), position);
-  }
-
-  @Override
-  public @Nullable Navigatable getNavigatable() {
-    return getNavigatable(new LineCol(0));
-  }
-
-  @Override
-  public @Nullable LineSeparator getLineSeparator() {
-    return mySeparator;
-  }
-
-  @Override
-  public @Nullable Boolean hasBom() {
-    return myBOM;
-  }
-
-  @Override
-  public @Nullable FileType getContentType() {
-    return myType;
-  }
-
-  @Override
-  public @Nullable Charset getCharset() {
-    return myCharset;
-  }
-
-  private static class MyNavigatable implements Navigatable {
-    
-    private final Project myProject;
-    
-    private final VirtualFile myTargetFile;
-    
     private final Document myDocument;
-    
-    private final LineCol myPosition;
 
-    public MyNavigatable(Project project, VirtualFile targetFile, Document document, LineCol position) {
-      myProject = project;
-      myTargetFile = targetFile;
-      myDocument = document;
-      myPosition = position;
+    private final @Nullable FileType myType;
+    private final @Nullable VirtualFile myHighlightFile;
+
+    private final @Nullable LineSeparator mySeparator;
+    private final @Nullable Charset myCharset;
+    private final @Nullable Boolean myBOM;
+
+    public DocumentContentImpl(Document document) {
+        this(null, document, null, null, null, null, null);
+    }
+
+    public DocumentContentImpl(
+        @Nullable Project project,
+        Document document,
+        @Nullable FileType type,
+        @Nullable VirtualFile highlightFile,
+        @Nullable LineSeparator separator,
+        @Nullable Charset charset,
+        @Nullable Boolean bom
+    ) {
+        myProject = project;
+        myDocument = document;
+        myType = type;
+        myHighlightFile = highlightFile;
+        mySeparator = separator;
+        myCharset = charset;
+        myBOM = bom;
+    }
+
+    public @Nullable Project getProject() {
+        return myProject;
     }
 
     @Override
-    public void navigate(boolean requestFocus) {
-      Document targetDocument = FileDocumentManager.getInstance().getDocument(myTargetFile);
-      LineCol targetPosition = translatePosition(myDocument, targetDocument, myPosition);
-      OpenFileDescriptor descriptor = OpenFileDescriptorFactory.getInstance(myProject)
-                                                               .newBuilder(myTargetFile)
-                                                               .line(targetPosition.line)
-                                                               .column(targetPosition.column)
-                                                               .build();
-      if (descriptor.canNavigate()) descriptor.navigate(true);
+    public Document getDocument() {
+        return myDocument;
     }
 
     @Override
-    public boolean canNavigate() {
-      return myTargetFile.isValid();
+    public @Nullable VirtualFile getHighlightFile() {
+        return myHighlightFile;
     }
 
     @Override
-    public boolean canNavigateToSource() {
-      return false;
+    public @Nullable Navigable getNavigable(LineCol position) {
+        if (myProject == null || getHighlightFile() == null || !getHighlightFile().isValid()) {
+            return null;
+        }
+        return new MyNavigable(myProject, getHighlightFile(), getDocument(), position);
     }
 
-    
-    private static LineCol translatePosition(Document fromDocument, @Nullable Document toDocument, LineCol position) {
-      try {
-        if (toDocument == null) return position;
-        int targetLine = Diff.translateLine(fromDocument.getCharsSequence(), toDocument.getCharsSequence(), position.line, true);
-        return new LineCol(targetLine, position.column);
-      }
-      catch (FilesTooBigForDiffException ignore) {
-        return position;
-      }
+    @Override
+    public @Nullable Navigable getNavigable() {
+        return getNavigable(new LineCol(0));
     }
-  }
+
+    @Override
+    public @Nullable LineSeparator getLineSeparator() {
+        return mySeparator;
+    }
+
+    @Override
+    public @Nullable Boolean hasBom() {
+        return myBOM;
+    }
+
+    @Override
+    public @Nullable FileType getContentType() {
+        return myType;
+    }
+
+    @Override
+    public @Nullable Charset getCharset() {
+        return myCharset;
+    }
+
+    private static class MyNavigable implements Navigatable {
+        private final Project myProject;
+
+        private final VirtualFile myTargetFile;
+
+        private final Document myDocument;
+
+        private final LineCol myPosition;
+
+        public MyNavigable(Project project, VirtualFile targetFile, Document document, LineCol position) {
+            myProject = project;
+            myTargetFile = targetFile;
+            myDocument = document;
+            myPosition = position;
+        }
+
+        @Override
+        @RequiredUIAccess
+        public void navigate(boolean requestFocus) {
+            Document targetDocument = FileDocumentManager.getInstance().getDocument(myTargetFile);
+            LineCol targetPosition = translatePosition(myDocument, targetDocument, myPosition);
+            OpenFileDescriptor descriptor = OpenFileDescriptorFactory.getInstance(myProject)
+                .newBuilder(myTargetFile)
+                .line(targetPosition.line)
+                .column(targetPosition.column)
+                .build();
+            if (descriptor.canNavigate()) {
+                descriptor.navigate(true);
+            }
+        }
+
+        @Override
+        @RequiredReadAction
+        public boolean canNavigate() {
+            return myTargetFile.isValid();
+        }
+
+        @Override
+        @RequiredReadAction
+        public boolean canNavigateToSource() {
+            return false;
+        }
+
+        private static LineCol translatePosition(Document fromDocument, @Nullable Document toDocument, LineCol position) {
+            try {
+                if (toDocument == null) {
+                    return position;
+                }
+                int targetLine = Diff.translateLine(fromDocument.getCharsSequence(), toDocument.getCharsSequence(), position.line, true);
+                return new LineCol(targetLine, position.column);
+            }
+            catch (FilesTooBigForDiffException ignore) {
+                return position;
+            }
+        }
+    }
 }

--- a/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/FileContentImpl.java
+++ b/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/FileContentImpl.java
@@ -19,9 +19,10 @@ import consulo.application.SaveAndSyncHandler;
 import consulo.diff.content.DiffContentBase;
 import consulo.diff.content.FileContent;
 import consulo.diff.internal.DiffImplUtil;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.virtualFileSystem.VirtualFile;
 import consulo.virtualFileSystem.fileType.FileType;
 import org.jspecify.annotations.Nullable;
@@ -30,58 +31,65 @@ import org.jspecify.annotations.Nullable;
  * Allows to compare files
  */
 public class FileContentImpl extends DiffContentBase implements FileContent {
-  
-  private final VirtualFile myFile;
-  private final @Nullable Project myProject;
-  
-  private final FileType myType;
-  private final @Nullable VirtualFile myHighlightFile;
+    private final VirtualFile myFile;
+    private final @Nullable Project myProject;
 
-  public FileContentImpl(@Nullable Project project, VirtualFile file) {
-    this(project, file, getHighlightFile(file));
-  }
+    private final FileType myType;
+    private final @Nullable VirtualFile myHighlightFile;
 
-  public FileContentImpl(@Nullable Project project,
-                         VirtualFile file,
-                         @Nullable VirtualFile highlightFile) {
-    assert file.isValid() && !file.isDirectory();
-    myFile = file;
-    myProject = project;
-    myType = file.getFileType();
-    myHighlightFile = highlightFile;
-  }
+    public FileContentImpl(@Nullable Project project, VirtualFile file) {
+        this(project, file, getHighlightFile(file));
+    }
 
-  @Override
-  public @Nullable Navigatable getNavigatable() {
-    if (myProject == null || myProject.isDefault()) return null;
-    if (myHighlightFile == null || !myHighlightFile.isValid()) return null;
-    return OpenFileDescriptorFactory.getInstance(myProject).newBuilder(myHighlightFile).build();
-  }
+    public FileContentImpl(
+        @Nullable Project project,
+        VirtualFile file,
+        @Nullable VirtualFile highlightFile
+    ) {
+        assert file.isValid() && !file.isDirectory();
+        myFile = file;
+        myProject = project;
+        myType = file.getFileType();
+        myHighlightFile = highlightFile;
+    }
 
-  private static @Nullable VirtualFile getHighlightFile(VirtualFile file) {
-    if (file.isInLocalFileSystem()) return file;
-    return null;
-  }
+    @Override
+    public @Nullable Navigable getNavigable() {
+        if (myProject == null || myProject.isDefault()) {
+            return null;
+        }
+        if (myHighlightFile == null || !myHighlightFile.isValid()) {
+            return null;
+        }
+        return OpenFileDescriptorFactory.getInstance(myProject).newBuilder(myHighlightFile).build();
+    }
 
-  
-  @Override
-  public VirtualFile getFile() {
-    return myFile;
-  }
+    private static @Nullable VirtualFile getHighlightFile(VirtualFile file) {
+        if (file.isInLocalFileSystem()) {
+            return file;
+        }
+        return null;
+    }
 
-  
-  @Override
-  public FileType getContentType() {
-    return myType;
-  }
+    @Override
+    public VirtualFile getFile() {
+        return myFile;
+    }
 
-  
-  public String getFilePath() {
-    return myFile.getPath();
-  }
+    @Override
+    public FileType getContentType() {
+        return myType;
+    }
 
-  @Override
-  public void onAssigned(boolean isAssigned) {
-    if (isAssigned && SaveAndSyncHandler.getInstance().isSyncOnFrameActivation()) DiffImplUtil.markDirtyAndRefresh(true, false, false, myFile);
-  }
+    public String getFilePath() {
+        return myFile.getPath();
+    }
+
+    @Override
+    @RequiredUIAccess
+    public void onAssigned(boolean isAssigned) {
+        if (isAssigned && SaveAndSyncHandler.getInstance().isSyncOnFrameActivation()) {
+            DiffImplUtil.markDirtyAndRefresh(true, false, false, myFile);
+        }
+    }
 }

--- a/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/FileDocumentContentImpl.java
+++ b/modules/base/diff-impl/src/main/java/consulo/diff/impl/internal/content/FileDocumentContentImpl.java
@@ -20,50 +20,54 @@ import consulo.diff.content.FileContent;
 import consulo.diff.internal.DiffImplUtil;
 import consulo.diff.util.LineCol;
 import consulo.document.Document;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.platform.LineSeparator;
 import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.virtualFileSystem.VirtualFile;
 import consulo.virtualFileSystem.internal.LoadTextUtil;
 import org.jspecify.annotations.Nullable;
 
 public class FileDocumentContentImpl extends DocumentContentImpl implements FileContent {
-  
-  private final VirtualFile myFile;
+    private final VirtualFile myFile;
 
-  public FileDocumentContentImpl(@Nullable Project project,
-                                 Document document,
-                                 VirtualFile file) {
-    super(project, document, file.getFileType(), file, getSeparator(file), file.getCharset(), file.getBOM() != null);
-    myFile = file;
-  }
+    public FileDocumentContentImpl(@Nullable Project project, Document document, VirtualFile file) {
+        super(project, document, file.getFileType(), file, getSeparator(file), file.getCharset(), file.getBOM() != null);
+        myFile = file;
+    }
 
-  @Override
-  public @Nullable Navigatable getNavigatable(LineCol position) {
-    Project project = getProject();
-    if (project == null || project.isDefault() || !myFile.isValid()) return null;
-    return OpenFileDescriptorFactory.getInstance(project)
-                                    .newBuilder(myFile)
-                                    .line(position.line)
-                                    .column(position.column)
-                                    .build();
-  }
+    @Override
+    public @Nullable Navigable getNavigable(LineCol position) {
+        Project project = getProject();
+        if (project == null || project.isDefault() || !myFile.isValid()) {
+            return null;
+        }
+        return OpenFileDescriptorFactory.getInstance(project)
+            .newBuilder(myFile)
+            .line(position.line)
+            .column(position.column)
+            .build();
+    }
 
-  private static @Nullable LineSeparator getSeparator(VirtualFile file) {
-    String s = LoadTextUtil.detectLineSeparator(file, true);
-    if (s == null) return null;
-    return LineSeparator.fromString(s);
-  }
+    private static @Nullable LineSeparator getSeparator(VirtualFile file) {
+        String s = LoadTextUtil.detectLineSeparator(file, true);
+        if (s == null) {
+            return null;
+        }
+        return LineSeparator.fromString(s);
+    }
 
-  
-  @Override
-  public VirtualFile getFile() {
-    return myFile;
-  }
+    @Override
+    public VirtualFile getFile() {
+        return myFile;
+    }
 
-  @Override
-  public void onAssigned(boolean isAssigned) {
-    if (isAssigned && SaveAndSyncHandler.getInstance().isSyncOnFrameActivation()) DiffImplUtil.markDirtyAndRefresh(true, false, false, myFile);
-  }
+    @Override
+    @RequiredUIAccess
+    public void onAssigned(boolean isAssigned) {
+        if (isAssigned && SaveAndSyncHandler.getInstance().isSyncOnFrameActivation()) {
+            DiffImplUtil.markDirtyAndRefresh(true, false, false, myFile);
+        }
+    }
 }

--- a/modules/base/execution-api/src/main/java/consulo/execution/service/ServiceViewDescriptor.java
+++ b/modules/base/execution-api/src/main/java/consulo/execution/service/ServiceViewDescriptor.java
@@ -1,8 +1,11 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package consulo.execution.service;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.annotation.access.RequiredReadAction;
 import consulo.dataContext.DataProvider;
 import consulo.navigation.ItemPresentation;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.ui.ex.action.ActionGroup;
 import consulo.util.dataholder.Key;
@@ -13,67 +16,74 @@ import java.awt.event.MouseEvent;
 import java.util.List;
 
 public interface ServiceViewDescriptor {
-  Key<Boolean> ACTION_HOLDER_KEY = Key.create("ServiceViewActionHolderContentComponent");
+    Key<Boolean> ACTION_HOLDER_KEY = Key.create("ServiceViewActionHolderContentComponent");
 
-  
-  ItemPresentation getPresentation();
+    ItemPresentation getPresentation();
 
-  default @Nullable String getId() {
-    return getPresentation().getPresentableText();
-  }
-
-  default @Nullable JComponent getContentComponent() {
-    return null;
-  }
-
-  default ItemPresentation getContentPresentation() {
-    return getPresentation();
-  }
-
-  default ItemPresentation getCustomPresentation(ServiceViewOptions options, ServiceViewItemState state) {
-    return getPresentation();
-  }
-
-  default @Nullable ActionGroup getToolbarActions() {
-    return null;
-  }
-
-  default @Nullable ActionGroup getPopupActions() {
-    return getToolbarActions();
-  }
-
-  default @Nullable DataProvider getDataProvider() {
-    return null;
-  }
-
-  default void onNodeSelected(List<Object> selectedServices) {
-  }
-
-  default void onNodeUnselected() {
-  }
-
-  default boolean handleDoubleClick(MouseEvent event) {
-    Navigatable navigatable = getNavigatable();
-    if (navigatable != null && navigatable.canNavigateToSource()) {
-      navigatable.navigate(true);
-      return true;
+    default @Nullable String getId() {
+        return getPresentation().getPresentableText();
     }
-    return false;
-  }
 
-  default @Nullable Object getPresentationTag(Object fragment) {
-    return null;
-  }
+    default @Nullable JComponent getContentComponent() {
+        return null;
+    }
 
-  default @Nullable Navigatable getNavigatable() {
-    return null;
-  }
+    default ItemPresentation getContentPresentation() {
+        return getPresentation();
+    }
 
-  default @Nullable Runnable getRemover() {
-    return null;
-  }
+    default ItemPresentation getCustomPresentation(ServiceViewOptions options, ServiceViewItemState state) {
+        return getPresentation();
+    }
 
-  default boolean isVisible() {
-    return true;
-  }
+    default @Nullable ActionGroup getToolbarActions() {
+        return null;
+    }
+
+    default @Nullable ActionGroup getPopupActions() {
+        return getToolbarActions();
+    }
+
+    default @Nullable DataProvider getDataProvider() {
+        return null;
+    }
+
+    default void onNodeSelected(List<Object> selectedServices) {
+    }
+
+    default void onNodeUnselected() {
+    }
+
+    @RequiredReadAction
+    default boolean handleDoubleClick(MouseEvent event) {
+        Navigable navigable = getNavigable();
+        if (navigable != null && navigable.canNavigateToSource()) {
+            navigable.navigate(true);
+            return true;
+        }
+        return false;
+    }
+
+    default @Nullable Object getPresentationTag(Object fragment) {
+        return null;
+    }
+
+    default @Nullable Navigable getNavigable() {
+        return null;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable() {
+        return (Navigatable) getNavigable();
+    }
+
+    default @Nullable Runnable getRemover() {
+        return null;
+    }
+
+    default boolean isVisible() {
+        return true;
+    }
 }

--- a/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/XSourcePosition.java
+++ b/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/XSourcePosition.java
@@ -13,32 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package consulo.execution.debug;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
+import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.virtualFileSystem.VirtualFile;
-import consulo.navigation.Navigatable;
 
 /**
  * Represents position in a source file. Use {@link XDebuggerUtil#createPosition} and {@link XDebuggerUtil#createPositionByOffset} to
  * create instances of this interface.
+ *
  * @author nik
  */
 public interface XSourcePosition {
-  /**
-   * @return 0-based number of line
-   */
-  int getLine();
+    /**
+     * @return 0-based number of line
+     */
+    int getLine();
 
-  /**
-   * @return offset from the beginning of file
-   */
-  int getOffset();
+    /**
+     * @return offset from the beginning of file
+     */
+    int getOffset();
 
-  
-  VirtualFile getFile();
+    VirtualFile getFile();
 
-  
-  Navigatable createNavigatable(Project project);
+    Navigable createNavigable(Project project);
+
+    @Deprecated
+    @DeprecationInfo("Use #createNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default Navigatable createNavigatable(Project project) {
+        return (Navigatable) createNavigable(project);
+    }
 }

--- a/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/XSourcePositionFactory.java
+++ b/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/XSourcePositionFactory.java
@@ -15,10 +15,12 @@
  */
 package consulo.execution.debug;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.annotation.UsedInPlugin;
 import consulo.annotation.component.ComponentScope;
 import consulo.annotation.component.ServiceAPI;
 import consulo.language.psi.PsiElement;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.virtualFileSystem.VirtualFile;
@@ -60,7 +62,14 @@ public interface XSourcePositionFactory {
 
     @Nullable XSourcePosition createPositionByElement(@Nullable PsiElement element);
 
-    
     @UsedInPlugin
-    Navigatable createDefaultNavigatable(Project project, XSourcePosition position);
+    Navigable createDefaultNavigable(Project project, XSourcePosition position);
+
+    @Deprecated
+    @DeprecationInfo("Use #createDefaultNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    @UsedInPlugin
+    default Navigatable createDefaultNavigatable(Project project, XSourcePosition position) {
+        return (Navigatable) createDefaultNavigable(project, position);
+    }
 }

--- a/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/breakpoint/XBreakpoint.java
+++ b/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/breakpoint/XBreakpoint.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package consulo.execution.debug.breakpoint;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.execution.debug.XBreakpointManager;
 import consulo.execution.debug.XSourcePosition;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.util.dataholder.UserDataHolder;
@@ -32,21 +33,26 @@ import org.jspecify.annotations.Nullable;
  * @see XBreakpointManager
  */
 public interface XBreakpoint<P extends XBreakpointProperties> extends UserDataHolder {
-
     boolean isEnabled();
 
     void setEnabled(boolean enabled);
 
-    
     XBreakpointType<?, P> getType();
 
     P getProperties();
 
-    @Nullable XSourcePosition getSourcePosition();
+    @Nullable
+    XSourcePosition getSourcePosition();
 
-    @Nullable Navigatable getNavigatable();
+    @Nullable Navigable getNavigable();
 
-    
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getNavigatable() {
+        return (Navigatable) getNavigable();
+    }
+
     SuspendPolicy getSuspendPolicy();
 
     void setSuspendPolicy(SuspendPolicy policy);
@@ -83,10 +89,8 @@ public interface XBreakpoint<P extends XBreakpointProperties> extends UserDataHo
 
     long getTimeStamp();
 
-    
     Project getProject();
 
-    
     XBreakpointManager getBreakpointManager();
 
     void fireBreakpointChanged();

--- a/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/frame/XNavigable.java
+++ b/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/frame/XNavigable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2009 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package consulo.navigation;
+package consulo.execution.debug.frame;
 
-import consulo.annotation.DeprecationInfo;
+import consulo.execution.debug.XSourcePosition;
 
-@Deprecated
-@DeprecationInfo("Use NonNavigable, typo-corrected name")
-@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
-public final class NonNavigatable extends NonNavigable {
-    NonNavigatable() {
-    }
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @author nik
+ */
+public interface XNavigable {
+    void setSourcePosition(@Nullable XSourcePosition sourcePosition);
 }

--- a/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/frame/XNavigatable.java
+++ b/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/frame/XNavigatable.java
@@ -15,13 +15,13 @@
  */
 package consulo.execution.debug.frame;
 
-import consulo.execution.debug.XSourcePosition;
-
-import org.jspecify.annotations.Nullable;
+import consulo.annotation.DeprecationInfo;
 
 /**
  * @author nik
  */
-public interface XNavigatable {
-  void setSourcePosition(@Nullable XSourcePosition sourcePosition);
+@Deprecated
+@DeprecationInfo("Use XNavigable, typo-corrected name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+public interface XNavigatable extends XNavigable {
 }

--- a/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/frame/XValue.java
+++ b/modules/base/execution-debug-api/src/main/java/consulo/execution/debug/frame/XValue.java
@@ -23,7 +23,6 @@ import consulo.execution.debug.evaluation.XInstanceEvaluator;
 import consulo.ui.image.Image;
 import consulo.util.concurrent.AsyncResult;
 import consulo.util.lang.ThreeState;
-
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,101 +32,105 @@ import org.jspecify.annotations.Nullable;
  * @author nik
  */
 public abstract class XValue extends XValueContainer {
-  /**
-   * Start computing presentation of the value in the debugger tree and call {@link XValueNode#setPresentation(Image, String, String, boolean)}
-   * when computation is finished.
-   * Note that this method is called from the Event Dispatch thread so it should return quickly.
-   * @param node node
-   * @param place where the node will be shown.
-   */
-  public abstract void computePresentation(XValueNode node, XValuePlace place);
+    /**
+     * Start computing presentation of the value in the debugger tree and call {@link XValueNode#setPresentation(Image, String, String, boolean)}
+     * when computation is finished.
+     * Note that this method is called from the Event Dispatch thread so it should return quickly.
+     *
+     * @param node  node
+     * @param place where the node will be shown.
+     */
+    public abstract void computePresentation(XValueNode node, XValuePlace place);
 
-  /**
-   * @return expression which evaluates to the current value
-   */
-  public @Nullable String getEvaluationExpression() {
-    return null;
-  }
+    /**
+     * @return expression which evaluates to the current value
+     */
+    public @Nullable String getEvaluationExpression() {
+        return null;
+    }
 
-  /**
-   * Asynchronously calculates expression which evaluates to the current value
-   */
-  public AsyncResult<XExpression> calculateEvaluationExpression() {
-    String expression = getEvaluationExpression();
-    XExpression res =
+    /**
+     * Asynchronously calculates expression which evaluates to the current value
+     */
+    public AsyncResult<XExpression> calculateEvaluationExpression() {
+        String expression = getEvaluationExpression();
+        XExpression res =
             expression != null ? XDebuggerUtil.getInstance().createExpression(expression, null, null, EvaluationMode.EXPRESSION) : null;
-    return AsyncResult.done(res);
-  }
+        return AsyncResult.done(res);
+    }
 
-  /**
-   * @return evaluator to calculate value of the current object instance
-   */
-  public @Nullable XInstanceEvaluator getInstanceEvaluator() {
-    return null;
-  }
+    /**
+     * @return evaluator to calculate value of the current object instance
+     */
+    public @Nullable XInstanceEvaluator getInstanceEvaluator() {
+        return null;
+    }
 
-  /**
-   * @return {@link XValueModifier} instance which can be used to modify the value
-   */
-  public @Nullable XValueModifier getModifier() {
-    return null;
-  }
+    /**
+     * @return {@link XValueModifier} instance which can be used to modify the value
+     */
+    public @Nullable XValueModifier getModifier() {
+        return null;
+    }
 
-  /**
-   * Start computing source position of the value and call {@link XNavigatable#setSourcePosition(XSourcePosition)}
-   * when computation is finished.
-   * Note that this method is called from the Event Dispatch thread so it should return quickly.
-   * @param navigatable navigatable
-   */
-  public void computeSourcePosition(XNavigatable navigatable) {
-    navigatable.setSourcePosition(null);
-  }
+    /**
+     * Start computing source position of the value and call {@link XNavigable#setSourcePosition(XSourcePosition)}
+     * when computation is finished.
+     * Note that this method is called from the Event Dispatch thread so it should return quickly.
+     *
+     * @param navigable navigable
+     */
+    public void computeSourcePosition(XNavigable navigable) {
+        navigable.setSourcePosition(null);
+    }
 
-  /**
-   * Provide inline debugger data, return ability to provide, use
-   * {@link ThreeState#UNSURE} if unsupported (default platform implementation will be used),
-   * {@link ThreeState#YES} if applicable
-   * {@link ThreeState#NO} if not applicable
-   */
-  public ThreeState computeInlineDebuggerData(XInlineDebuggerDataCallback callback) {
-    return ThreeState.UNSURE;
-  }
+    /**
+     * Provide inline debugger data, return ability to provide, use
+     * {@link ThreeState#UNSURE} if unsupported (default platform implementation will be used),
+     * {@link ThreeState#YES} if applicable
+     * {@link ThreeState#NO} if not applicable
+     */
+    public ThreeState computeInlineDebuggerData(XInlineDebuggerDataCallback callback) {
+        return ThreeState.UNSURE;
+    }
 
-  /**
-   * Return {@code true} from this method and override {@link #computeSourcePosition(XNavigatable)} if navigation to the source
-   * is supported for the value
-   * @return {@code true} if navigation to the value's source is supported
-   */
-  public boolean canNavigateToSource() {
-    // should be false, but cannot be due to compatibility reasons
-    return true;
-  }
+    /**
+     * Return {@code true} from this method and override {@link #computeSourcePosition(XNavigable)} if navigation to the source
+     * is supported for the value
+     *
+     * @return {@code true} if navigation to the value's source is supported
+     */
+    public boolean canNavigateToSource() {
+        // should be false, but cannot be due to compatibility reasons
+        return true;
+    }
 
-  /**
-   * Return {@code true} from this method and override {@link #computeTypeSourcePosition(XNavigatable)} if navigation to the value's type
-   * is supported for the value
-   * @return {@code true} if navigation to the value's type is supported
-   */
-  public boolean canNavigateToTypeSource() {
-    return false;
-  }
+    /**
+     * Return {@code true} from this method and override {@link #computeTypeSourcePosition(XNavigable)} if navigation to the value's type
+     * is supported for the value
+     *
+     * @return {@code true} if navigation to the value's type is supported
+     */
+    public boolean canNavigateToTypeSource() {
+        return false;
+    }
 
-  /**
-   * Start computing source position of the value's type and call {@link XNavigatable#setSourcePosition(XSourcePosition)}
-   * when computation is finished.
-   * Note that this method is called from the Event Dispatch thread so it should return quickly.
-   */
-  public void computeTypeSourcePosition(XNavigatable navigatable) {
-    navigatable.setSourcePosition(null);
-  }
+    /**
+     * Start computing source position of the value's type and call {@link XNavigable#setSourcePosition(XSourcePosition)}
+     * when computation is finished.
+     * Note that this method is called from the Event Dispatch thread so it should return quickly.
+     */
+    public void computeTypeSourcePosition(XNavigable navigable) {
+        navigable.setSourcePosition(null);
+    }
 
-  /**
-   * This enables showing referrers for the value
-   *
-   * @return provider that creates an XValue returning objects that refer to the current value
-   * or null if showing referrers for the value is disabled
-   */
-  public @Nullable XReferrersProvider getReferrersProvider() {
-    return null;
-  }
+    /**
+     * This enables showing referrers for the value
+     *
+     * @return provider that creates an XValue returning objects that refer to the current value
+     * or null if showing referrers for the value is disabled
+     */
+    public @Nullable XReferrersProvider getReferrersProvider() {
+        return null;
+    }
 }

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/XSourcePositionFactoryImpl.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/XSourcePositionFactoryImpl.java
@@ -15,15 +15,18 @@
  */
 package consulo.execution.debug.impl.internal;
 
+import consulo.annotation.access.RequiredReadAction;
 import consulo.annotation.component.ServiceImpl;
 import consulo.execution.debug.XSourcePosition;
 import consulo.execution.debug.XSourcePositionFactory;
 import consulo.language.psi.PsiElement;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.virtualFileSystem.VirtualFile;
-import org.jspecify.annotations.Nullable;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author VISTALL
@@ -32,26 +35,29 @@ import jakarta.inject.Singleton;
 @ServiceImpl
 @Singleton
 public class XSourcePositionFactoryImpl implements XSourcePositionFactory {
-    public static class XSourcePositionNavigatable implements Navigatable {
+    public static class XSourcePositionNavigable implements Navigatable {
         private final Project myProject;
         private final XSourcePosition myPosition;
 
-        public XSourcePositionNavigatable(Project project, XSourcePosition position) {
+        public XSourcePositionNavigable(Project project, XSourcePosition position) {
             myProject = project;
             myPosition = position;
         }
 
         @Override
+        @RequiredUIAccess
         public void navigate(boolean requestFocus) {
             XSourcePositionImpl.createOpenFileDescriptor(myProject, myPosition).navigate(requestFocus);
         }
 
         @Override
+        @RequiredReadAction
         public boolean canNavigate() {
             return myPosition.getFile().isValid();
         }
 
         @Override
+        @RequiredReadAction
         public boolean canNavigateToSource() {
             return canNavigate();
         }
@@ -77,9 +83,8 @@ public class XSourcePositionFactoryImpl implements XSourcePositionFactory {
         return XSourcePositionImpl.createByElement(element);
     }
 
-    
     @Override
-    public Navigatable createDefaultNavigatable(Project project, XSourcePosition position) {
-        return new XSourcePositionNavigatable(project, position);
+    public Navigable createDefaultNavigable(Project project, XSourcePosition position) {
+        return new XSourcePositionNavigable(project, position);
     }
 }

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/XSourcePositionImpl.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/XSourcePositionImpl.java
@@ -2,6 +2,7 @@
 package consulo.execution.debug.impl.internal;
 
 import com.uber.nullaway.annotations.Contract;
+import consulo.annotation.access.RequiredReadAction;
 import consulo.application.ReadAction;
 import consulo.application.util.AtomicNotNullLazyValue;
 import consulo.document.Document;
@@ -14,8 +15,8 @@ import consulo.language.psi.PsiElement;
 import consulo.language.psi.PsiFile;
 import consulo.language.psi.SmartPointerManager;
 import consulo.language.psi.SmartPsiElementPointer;
-import consulo.navigation.Navigatable;
-import consulo.navigation.NonNavigatable;
+import consulo.navigation.Navigable;
+import consulo.navigation.NonNavigable;
 import consulo.navigation.OpenFileDescriptor;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.project.Project;
@@ -112,18 +113,17 @@ public abstract class XSourcePositionImpl implements XSourcePosition {
                 return myDelegate.getValue().getOffset();
             }
 
-            
             @Override
-            public Navigatable createNavigatable(Project project) {
+            @RequiredReadAction
+            public Navigable createNavigable(Project project) {
                 // no need to create delegate here, it may be expensive
                 if (myDelegate.isComputed()) {
-                    return myDelegate.getValue().createNavigatable(project);
+                    return myDelegate.getValue().createNavigable(project);
                 }
-                PsiElement elem = pointer.getElement();
-                if (elem instanceof Navigatable) {
-                    return ((Navigatable) elem);
+                if (pointer.getElement() instanceof Navigable navigable) {
+                    return navigable;
                 }
-                return NonNavigatable.INSTANCE;
+                return NonNavigable.INSTANCE;
             }
         };
     }
@@ -187,12 +187,10 @@ public abstract class XSourcePositionImpl implements XSourcePosition {
     }
 
     @Override
-    
-    public Navigatable createNavigatable(Project project) {
-        return new XSourcePositionFactoryImpl.XSourcePositionNavigatable(project, this);
+    public Navigable createNavigable(Project project) {
+        return new XSourcePositionFactoryImpl.XSourcePositionNavigable(project, this);
     }
 
-    
     public static OpenFileDescriptor createOpenFileDescriptor(Project project, XSourcePosition position) {
         OpenFileDescriptorFactory factory = OpenFileDescriptorFactory.getInstance(project);
 

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/breakpoint/XBreakpointBase.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/breakpoint/XBreakpointBase.java
@@ -30,7 +30,7 @@ import consulo.execution.debug.internal.breakpoint.BreakpointEditorUtil;
 import consulo.execution.debug.localize.XDebuggerLocalize;
 import consulo.execution.debug.setting.XDebuggerSettingsManager;
 import consulo.localize.LocalizeValue;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.ui.ex.JBColor;
 import consulo.ui.ex.action.ActionGroup;
@@ -45,8 +45,8 @@ import consulo.util.lang.xml.CommonXmlStrings;
 import consulo.util.lang.xml.XmlStringUtil;
 import consulo.util.xml.serializer.SkipDefaultValuesSerializationFilters;
 import consulo.util.xml.serializer.XmlSerializer;
-import org.jspecify.annotations.Nullable;
 import org.jdom.Element;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -104,13 +104,11 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
         myLogExpression = expression != null ? expression.toXExpression() : null;
     }
 
-    
     @Override
     public final Project getProject() {
         return myBreakpointManager.getProject();
     }
 
-    
     @Override
     public XBreakpointManagerImpl getBreakpointManager() {
         return myBreakpointManager;
@@ -128,12 +126,12 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
     }
 
     @Override
-    public Navigatable getNavigatable() {
+    public Navigable getNavigable() {
         XSourcePosition position = getSourcePosition();
         if (position == null) {
             return null;
         }
-        return position.createNavigatable(getProject());
+        return position.createNavigable(getProject());
     }
 
     @Override
@@ -150,7 +148,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
     }
 
     @Override
-    
     public SuspendPolicy getSuspendPolicy() {
         return myState.getSuspendPolicy();
     }
@@ -276,7 +273,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
     }
 
     @Override
-    
     public XBreakpointType<Self, P> getType() {
         return myType;
     }
@@ -338,7 +334,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
         return Collections.emptyList();
     }
 
-    
     public String getDescription() {
         StringBuilder builder = new StringBuilder();
         builder.append(CommonXmlStrings.HTML_START).append(CommonXmlStrings.BODY_START);
@@ -459,7 +454,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
         return null;
     }
 
-    
     public Image getIcon() {
         if (myIcon == null) {
             updateIcon();
@@ -489,7 +483,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
         myCustomizedPresentation = presentation;
     }
 
-    
     public GutterIconRenderer createGutterIconRenderer() {
         return new BreakpointGutterIconRenderer();
     }
@@ -506,7 +499,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
 
     protected class BreakpointGutterIconRenderer extends GutterIconRenderer implements DumbAware {
         @Override
-        
         public Image getIcon() {
             return XBreakpointBase.this.getIcon();
         }
@@ -541,7 +533,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
             );
         }
 
-        
         @Override
         public Alignment getAlignment() {
             return BreakpointEditorUtil.isBreakPointsOnLineNumbers() ? Alignment.LINE_NUMBERS : Alignment.RIGHT;
@@ -552,7 +543,6 @@ public class XBreakpointBase<Self extends XBreakpoint<P>, P extends XBreakpointP
             return null;
         }
 
-        
         @Override
         public LocalizeValue getTooltipValue() {
             return LocalizeValue.localizeTODO(getDescription());

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/action/XJumpToSourceAction.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/action/XJumpToSourceAction.java
@@ -17,7 +17,7 @@ package consulo.execution.debug.impl.internal.ui.tree.action;
 
 import consulo.annotation.component.ActionImpl;
 import consulo.execution.debug.XDebuggerActions;
-import consulo.execution.debug.frame.XNavigatable;
+import consulo.execution.debug.frame.XNavigable;
 import consulo.execution.debug.frame.XValue;
 import consulo.execution.debug.impl.internal.ui.tree.node.XValueNodeImpl;
 import consulo.execution.debug.localize.XDebuggerLocalize;
@@ -33,8 +33,8 @@ public class XJumpToSourceAction extends XJumpToSourceActionBase {
     }
 
     @Override
-    protected void startComputingSourcePosition(XValue value, XNavigatable navigatable) {
-        value.computeSourcePosition(navigatable);
+    protected void startComputingSourcePosition(XValue value, XNavigable navigable) {
+        value.computeSourcePosition(navigable);
     }
 
     @Override

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/action/XJumpToSourceActionBase.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/action/XJumpToSourceActionBase.java
@@ -15,7 +15,7 @@
  */
 package consulo.execution.debug.impl.internal.ui.tree.action;
 
-import consulo.execution.debug.frame.XNavigatable;
+import consulo.execution.debug.frame.XNavigable;
 import consulo.execution.debug.frame.XValue;
 import consulo.execution.debug.impl.internal.ui.tree.node.XValueNodeImpl;
 import consulo.localize.LocalizeValue;
@@ -34,7 +34,7 @@ public abstract class XJumpToSourceActionBase extends XDebuggerTreeActionBase {
     @Override
     protected void perform(XValueNodeImpl node, String nodeName, AnActionEvent e) {
         XValue value = node.getValueContainer();
-        XNavigatable navigatable = sourcePosition -> {
+        XNavigable navigable = sourcePosition -> {
             if (sourcePosition != null) {
                 AppUIUtil.invokeOnEdt(() -> {
                     Project project = node.getTree().getProject();
@@ -42,12 +42,12 @@ public abstract class XJumpToSourceActionBase extends XDebuggerTreeActionBase {
                         return;
                     }
 
-                    sourcePosition.createNavigatable(project).navigate(true);
+                    sourcePosition.createNavigable(project).navigate(true);
                 });
             }
         };
-        startComputingSourcePosition(value, navigatable);
+        startComputingSourcePosition(value, navigable);
     }
 
-    protected abstract void startComputingSourcePosition(XValue value, XNavigatable navigatable);
+    protected abstract void startComputingSourcePosition(XValue value, XNavigable navigable);
 }

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/action/XJumpToTypeSourceAction.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/action/XJumpToTypeSourceAction.java
@@ -17,7 +17,7 @@ package consulo.execution.debug.impl.internal.ui.tree.action;
 
 import consulo.annotation.component.ActionImpl;
 import consulo.execution.debug.XDebuggerActions;
-import consulo.execution.debug.frame.XNavigatable;
+import consulo.execution.debug.frame.XNavigable;
 import consulo.execution.debug.frame.XValue;
 import consulo.execution.debug.impl.internal.ui.tree.node.XValueNodeImpl;
 import consulo.execution.debug.localize.XDebuggerLocalize;
@@ -33,8 +33,8 @@ public class XJumpToTypeSourceAction extends XJumpToSourceActionBase {
     }
 
     @Override
-    protected void startComputingSourcePosition(XValue value, XNavigatable navigatable) {
-        value.computeTypeSourcePosition(navigatable);
+    protected void startComputingSourcePosition(XValue value, XNavigable navigable) {
+        value.computeTypeSourcePosition(navigable);
     }
 
     @Override

--- a/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/node/WatchNodeImpl.java
+++ b/modules/base/execution-debug-impl/src/main/java/consulo/execution/debug/impl/internal/ui/tree/node/WatchNodeImpl.java
@@ -24,8 +24,8 @@ import consulo.execution.debug.frame.*;
 import consulo.execution.debug.frame.presentation.XErrorValuePresentation;
 import consulo.execution.debug.frame.presentation.XValuePresentation;
 import consulo.execution.debug.icon.ExecutionDebugIconGroup;
-import consulo.execution.debug.internal.XEvaluationCallbackBase;
 import consulo.execution.debug.impl.internal.ui.tree.XDebuggerTree;
+import consulo.execution.debug.internal.XEvaluationCallbackBase;
 import consulo.execution.debug.ui.XDebuggerUIConstants;
 import consulo.localize.LocalizeValue;
 import consulo.util.concurrent.AsyncResult;
@@ -182,9 +182,9 @@ public class WatchNodeImpl extends XValueNodeImpl implements WatchNode {
         }
 
         @Override
-        public void computeSourcePosition(XNavigatable navigatable) {
+        public void computeSourcePosition(XNavigable navigable) {
             if (myValue != null) {
-                myValue.computeSourcePosition(navigatable);
+                myValue.computeSourcePosition(navigable);
             }
         }
 
@@ -204,9 +204,9 @@ public class WatchNodeImpl extends XValueNodeImpl implements WatchNode {
         }
 
         @Override
-        public void computeTypeSourcePosition(XNavigatable navigatable) {
+        public void computeTypeSourcePosition(XNavigable navigable) {
             if (myValue != null) {
-                myValue.computeTypeSourcePosition(navigatable);
+                myValue.computeTypeSourcePosition(navigable);
             }
         }
 

--- a/modules/base/execution-impl/src/main/java/consulo/execution/impl/internal/dashboard/RunDashboardServiceViewContributor.java
+++ b/modules/base/execution-impl/src/main/java/consulo/execution/impl/internal/dashboard/RunDashboardServiceViewContributor.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package consulo.execution.impl.internal.dashboard;
 
+import consulo.annotation.access.RequiredReadAction;
 import consulo.annotation.component.ExtensionImpl;
 import consulo.application.Application;
 import consulo.application.ReadAction;
@@ -26,11 +27,13 @@ import consulo.language.psi.PsiElement;
 import consulo.language.psi.PsiUtilCore;
 import consulo.language.psi.util.PsiNavigateUtil;
 import consulo.navigation.ItemPresentation;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.process.ProcessHandler;
 import consulo.project.Project;
 import consulo.project.ui.view.tree.AbstractTreeNode;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.DeleteProvider;
 import consulo.ui.ex.action.*;
 import consulo.ui.ex.awt.dnd.DnDEvent;
@@ -321,7 +324,7 @@ public final class RunDashboardServiceViewContributor
         }
 
         @Override
-        public @Nullable Navigatable getNavigatable() {
+        public @Nullable Navigable getNavigable() {
             Supplier<PsiElement> value = LazyValue.nullable(() -> {
                 for (RunDashboardCustomizer customizer : myNode.getCustomizers()) {
                     PsiElement psiElement = customizer.getPsiElement(myNode);
@@ -333,21 +336,23 @@ public final class RunDashboardServiceViewContributor
             });
             return new Navigatable() {
                 @Override
+                @RequiredUIAccess
                 public void navigate(boolean requestFocus) {
                     PsiNavigateUtil.navigate(value.get(), requestFocus);
                 }
 
                 @Override
+                @RequiredReadAction
                 public boolean canNavigate() {
                     return value.get() != null;
                 }
 
                 @Override
+                @RequiredReadAction
                 public boolean canNavigateToSource() {
                     return canNavigate();
                 }
             };
-
         }
 
         @Override

--- a/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/SMStacktraceParser.java
+++ b/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/SMStacktraceParser.java
@@ -15,8 +15,10 @@
  */
 package consulo.execution.test.sm;
 
-import consulo.project.Project;
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
+import consulo.project.Project;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,5 +27,12 @@ import org.jspecify.annotations.Nullable;
  */
 @Deprecated
 public interface SMStacktraceParser {
-    @Nullable Navigatable getErrorNavigatable(Project project, String stacktrace);
+    @Nullable Navigable getErrorNavigable(Project project, String stacktrace);
+
+    @Deprecated
+    @DeprecationInfo("Use #getErrorNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    default @Nullable Navigatable getErrorNavigatable(Project project, String stacktrace) {
+        return (Navigatable) getErrorNavigable(project, stacktrace);
+    }
 }

--- a/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/SMStacktraceParserEx.java
+++ b/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/SMStacktraceParserEx.java
@@ -16,10 +16,9 @@
 package consulo.execution.test.sm;
 
 import consulo.execution.action.Location;
-import consulo.navigation.Navigatable;
-
+import consulo.navigation.Navigable;
 import org.jspecify.annotations.Nullable;
 
 public interface SMStacktraceParserEx extends SMStacktraceParser {
-    @Nullable Navigatable getErrorNavigatable(Location<?> location, String stacktrace);
+    @Nullable Navigable getErrorNavigable(Location<?> location, String stacktrace);
 }

--- a/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/runner/SMTRunnerConsoleProperties.java
+++ b/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/runner/SMTRunnerConsoleProperties.java
@@ -33,6 +33,7 @@ import consulo.language.psi.PsiDocumentManager;
 import consulo.language.psi.PsiElement;
 import consulo.language.psi.PsiFile;
 import consulo.language.psi.PsiWhiteSpace;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.navigation.OpenFileDescriptorFactory;
 import consulo.project.Project;
@@ -40,7 +41,6 @@ import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.AnAction;
 import consulo.util.lang.StringUtil;
 import consulo.virtualFileSystem.VirtualFile;
-
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -110,17 +110,17 @@ public class SMTRunnerConsoleProperties extends TestConsoleProperties implements
     }
 
     @Override
-    public @Nullable Navigatable getErrorNavigatable(Location<?> location, String stacktrace) {
-        return getErrorNavigatable(location.getProject(), stacktrace);
+    public @Nullable Navigable getErrorNavigable(Location<?> location, String stacktrace) {
+        return getErrorNavigable(location.getProject(), stacktrace);
     }
 
     @Override
-    public @Nullable Navigatable getErrorNavigatable(final Project project, String stacktrace) {
+    public @Nullable Navigable getErrorNavigable(final Project project, String stacktrace) {
         if (myCustomFilter.isEmpty()) {
             return null;
         }
 
-        // iterate stacktrace lines find first navigatable line using
+        // iterate stacktrace lines find first navigable line using
         // stacktrace filters
         int stacktraceLength = stacktrace.length();
         String[] lines = StringUtil.splitByLines(stacktrace);
@@ -149,11 +149,13 @@ public class SMTRunnerConsoleProperties extends TestConsoleProperties implements
                     }
 
                     @Override
+                    @RequiredReadAction
                     public boolean canNavigate() {
                         return true;
                     }
 
                     @Override
+                    @RequiredReadAction
                     public boolean canNavigateToSource() {
                         return true;
                     }
@@ -206,7 +208,6 @@ public class SMTRunnerConsoleProperties extends TestConsoleProperties implements
         return null;
     }
 
-    
     public String getTestFrameworkName() {
         return myTestFrameworkName;
     }

--- a/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/runner/SMTestProxy.java
+++ b/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/runner/SMTestProxy.java
@@ -15,6 +15,7 @@
  */
 package consulo.execution.test.sm.runner;
 
+import consulo.annotation.access.RequiredReadAction;
 import consulo.disposer.Disposer;
 import consulo.execution.action.Location;
 import consulo.execution.test.*;
@@ -28,6 +29,7 @@ import consulo.execution.ui.console.ConsoleViewContentType;
 import consulo.language.psi.scope.GlobalSearchScope;
 import consulo.language.psi.util.EditSourceUtil;
 import consulo.logging.Logger;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.process.ProcessHandler;
 import consulo.process.ProcessOutputTypes;
@@ -58,7 +60,7 @@ public class SMTestProxy extends AbstractTestProxy {
     private final String myName;
     private boolean myIsSuite;
     private final String myLocationUrl;
-    private final String myMetainfo;
+    private final String myMetaInfo;
     private final boolean myPreservePresentableName;
 
     private List<SMTestProxy> myChildren;
@@ -94,13 +96,13 @@ public class SMTestProxy extends AbstractTestProxy {
         String testName,
         boolean isSuite,
         @Nullable String locationUrl,
-        @Nullable String metainfo,
+        @Nullable String metaInfo,
         boolean preservePresentableName
     ) {
         myName = testName;
         myIsSuite = isSuite;
         myLocationUrl = locationUrl;
-        myMetainfo = metainfo;
+        myMetaInfo = metaInfo;
         myPreservePresentableName = preservePresentableName;
     }
 
@@ -277,7 +279,7 @@ public class SMTestProxy extends AbstractTestProxy {
                 String path = VirtualFileManager.extractPath(locationUrl);
                 if (!DumbService.isDumb(project) || DumbService.isDumbAware(myLocator)) {
                     return DumbService.getInstance(project).computeWithAlternativeResolveEnabled(() -> {
-                        List<Location> locations = myLocator.getLocation(protocolId, path, myMetainfo, project, searchScope);
+                        List<Location> locations = myLocator.getLocation(protocolId, path, myMetaInfo, project, searchScope);
                         return !locations.isEmpty() ? locations.get(0) : null;
                     });
                 }
@@ -288,8 +290,9 @@ public class SMTestProxy extends AbstractTestProxy {
     }
 
     @Override
+    @RequiredReadAction
     public @Nullable Navigatable getDescriptor(@Nullable Location location, TestConsoleProperties properties) {
-        // by location gets navigatable element.
+        // by location gets navigable element.
         // It can be file or place in file (e.g. when OPEN_FAILURE_LINE is enabled)
         if (location == null) {
             return null;
@@ -297,11 +300,11 @@ public class SMTestProxy extends AbstractTestProxy {
 
         String stacktrace = myStacktrace;
         if (stacktrace != null && properties instanceof SMStacktraceParser stacktraceParser && isLeaf()) {
-            Navigatable result = stacktraceParser instanceof SMStacktraceParserEx stacktraceParserEx
-                ? stacktraceParserEx.getErrorNavigatable(location, stacktrace)
-                : stacktraceParser.getErrorNavigatable(location.getProject(), stacktrace);
+            Navigable result = stacktraceParser instanceof SMStacktraceParserEx stacktraceParserEx
+                ? stacktraceParserEx.getErrorNavigable(location, stacktrace)
+                : stacktraceParser.getErrorNavigable(location.getProject(), stacktrace);
             if (result != null) {
-                return result;
+                return (Navigatable) result;
             }
         }
 
@@ -758,7 +761,7 @@ public class SMTestProxy extends AbstractTestProxy {
 
     @Override
     public @Nullable String getMetainfo() {
-        return myMetainfo;
+        return myMetaInfo;
     }
 
     /**

--- a/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/runner/history/ImportedTestConsoleProperties.java
+++ b/modules/base/execution-test-sm-api/src/main/java/consulo/execution/test/sm/runner/history/ImportedTestConsoleProperties.java
@@ -24,11 +24,10 @@ import consulo.execution.test.sm.SMCustomMessagesParsing;
 import consulo.execution.test.sm.runner.*;
 import consulo.execution.ui.console.ConsoleView;
 import consulo.execution.ui.console.Filter;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.process.ProcessHandler;
 import consulo.project.Project;
 import consulo.ui.ex.action.DefaultActionGroup;
-
 import org.jspecify.annotations.Nullable;
 
 import javax.swing.*;
@@ -73,13 +72,13 @@ public class ImportedTestConsoleProperties extends SMTRunnerConsoleProperties im
     }
 
     @Override
-    public @Nullable Navigatable getErrorNavigatable(Location<?> location, String stacktrace) {
-        return myProperties == null ? null : myProperties.getErrorNavigatable(location, stacktrace);
+    public @Nullable Navigable getErrorNavigable(Location<?> location, String stacktrace) {
+        return myProperties == null ? null : myProperties.getErrorNavigable(location, stacktrace);
     }
 
     @Override
-    public @Nullable Navigatable getErrorNavigatable(Project project, String stacktrace) {
-        return myProperties == null ? null : myProperties.getErrorNavigatable(project, stacktrace);
+    public @Nullable Navigable getErrorNavigable(Project project, String stacktrace) {
+        return myProperties == null ? null : myProperties.getErrorNavigable(project, stacktrace);
     }
 
     @Override

--- a/modules/base/external-system-api/src/main/java/consulo/externalSystem/service/notification/NotificationData.java
+++ b/modules/base/external-system-api/src/main/java/consulo/externalSystem/service/notification/NotificationData.java
@@ -15,11 +15,14 @@
  */
 package consulo.externalSystem.service.notification;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.ui.notification.Notification;
 import consulo.project.ui.notification.event.NotificationListener;
-
+import consulo.ui.annotation.RequiredUIAccess;
 import org.jspecify.annotations.Nullable;
+
 import javax.swing.event.HyperlinkEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,152 +31,165 @@ import java.util.Map;
 
 /**
  * @author Vladislav.Soroka
- * @since 3/28/14
+ * @since 2017-03-28
  */
 public class NotificationData {
+    private String myTitle;
 
-  
-  private String myTitle;
-  
-  private String myMessage;
-  
-  private NotificationCategory myNotificationCategory;
-  
-  private final NotificationSource myNotificationSource;
-  
-  private NotificationListener myListener;
-  private @Nullable String myFilePath;
-  private @Nullable Navigatable navigatable;
-  private int myLine;
-  private int myColumn;
-  private boolean myBalloonNotification;
+    private String myMessage;
 
-  private final Map<String, NotificationListener> myListenerMap;
+    private NotificationCategory myNotificationCategory;
 
-  public NotificationData(String title,
-                          String message,
-                          NotificationCategory notificationCategory,
-                          NotificationSource notificationSource) {
-    this(title, message, notificationCategory, notificationSource, null, -1, -1, false);
-  }
+    private final NotificationSource myNotificationSource;
 
-  public NotificationData(String title,
-                          String message,
-                          NotificationCategory notificationCategory,
-                          NotificationSource notificationSource,
-                          @Nullable String filePath,
-                          int line,
-                          int column,
-                          boolean balloonNotification) {
-    myTitle = title;
-    myMessage = message;
-    myNotificationCategory = notificationCategory;
-    myNotificationSource = notificationSource;
-    myListenerMap = new HashMap<>();
-    myListener = new NotificationListener.Adapter() {
-      @Override
-      protected void hyperlinkActivated(Notification notification, HyperlinkEvent event) {
-        if (event.getEventType() != HyperlinkEvent.EventType.ACTIVATED) return;
+    private NotificationListener myListener;
+    private @Nullable String myFilePath;
+    private @Nullable Navigable myNavigable;
+    private int myLine;
+    private int myColumn;
+    private boolean myBalloonNotification;
 
-        NotificationListener notificationListener = myListenerMap.get(event.getDescription());
-        if (notificationListener != null) {
-          notificationListener.hyperlinkUpdate(notification, event);
-        }
-      }
-    };
-    myFilePath = filePath;
-    myLine = line;
-    myColumn = column;
-    myBalloonNotification = balloonNotification;
-  }
+    private final Map<String, NotificationListener> myListenerMap;
 
-  
-  public String getTitle() {
-    return myTitle;
-  }
+    public NotificationData(
+        String title,
+        String message,
+        NotificationCategory notificationCategory,
+        NotificationSource notificationSource
+    ) {
+        this(title, message, notificationCategory, notificationSource, null, -1, -1, false);
+    }
 
-  public void setTitle(String title) {
-    myTitle = title;
-  }
+    public NotificationData(
+        String title,
+        String message,
+        NotificationCategory notificationCategory,
+        NotificationSource notificationSource,
+        @Nullable String filePath,
+        int line,
+        int column,
+        boolean balloonNotification
+    ) {
+        myTitle = title;
+        myMessage = message;
+        myNotificationCategory = notificationCategory;
+        myNotificationSource = notificationSource;
+        myListenerMap = new HashMap<>();
+        myListener = new NotificationListener.Adapter() {
+            @Override
+            @RequiredUIAccess
+            protected void hyperlinkActivated(Notification notification, HyperlinkEvent event) {
+                if (event.getEventType() != HyperlinkEvent.EventType.ACTIVATED) {
+                    return;
+                }
 
-  
-  public String getMessage() {
-    return myMessage;
-  }
+                NotificationListener notificationListener = myListenerMap.get(event.getDescription());
+                if (notificationListener != null) {
+                    notificationListener.hyperlinkUpdate(notification, event);
+                }
+            }
+        };
+        myFilePath = filePath;
+        myLine = line;
+        myColumn = column;
+        myBalloonNotification = balloonNotification;
+    }
 
-  public void setMessage(String message) {
-    myMessage = message;
-  }
+    public String getTitle() {
+        return myTitle;
+    }
 
-  
-  public NotificationCategory getNotificationCategory() {
-    return myNotificationCategory;
-  }
+    public void setTitle(String title) {
+        myTitle = title;
+    }
 
-  public void setNotificationCategory(NotificationCategory notificationCategory) {
-    myNotificationCategory = notificationCategory;
-  }
+    public String getMessage() {
+        return myMessage;
+    }
 
-  
-  public NotificationSource getNotificationSource() {
-    return myNotificationSource;
-  }
+    public void setMessage(String message) {
+        myMessage = message;
+    }
 
-  
-  public NotificationListener getListener() {
-    return myListener;
-  }
+    public NotificationCategory getNotificationCategory() {
+        return myNotificationCategory;
+    }
 
-  public @Nullable String getFilePath() {
-    return myFilePath;
-  }
+    public void setNotificationCategory(NotificationCategory notificationCategory) {
+        myNotificationCategory = notificationCategory;
+    }
 
-  public void setFilePath(@Nullable String filePath) {
-    myFilePath = filePath;
-  }
+    public NotificationSource getNotificationSource() {
+        return myNotificationSource;
+    }
 
-  
-  public Integer getLine() {
-    return myLine;
-  }
+    public NotificationListener getListener() {
+        return myListener;
+    }
 
-  public void setLine(int line) {
-    myLine = line;
-  }
+    public @Nullable String getFilePath() {
+        return myFilePath;
+    }
 
-  public int getColumn() {
-    return myColumn;
-  }
+    public void setFilePath(@Nullable String filePath) {
+        myFilePath = filePath;
+    }
 
-  public void setColumn(int column) {
-    myColumn = column;
-  }
+    public Integer getLine() {
+        return myLine;
+    }
 
-  public boolean isBalloonNotification() {
-    return myBalloonNotification;
-  }
+    public void setLine(int line) {
+        myLine = line;
+    }
 
-  public void setBalloonNotification(boolean balloonNotification) {
-    myBalloonNotification = balloonNotification;
-  }
+    public int getColumn() {
+        return myColumn;
+    }
 
-  public void setListener(String listenerId, NotificationListener listener) {
-    myListenerMap.put(listenerId, listener);
-  }
+    public void setColumn(int column) {
+        myColumn = column;
+    }
 
-  public boolean hasLinks() {
-    return !myListenerMap.isEmpty();
-  }
+    public boolean isBalloonNotification() {
+        return myBalloonNotification;
+    }
 
-  public List<String> getRegisteredListenerIds() {
-    return new ArrayList<>(myListenerMap.keySet());
-  }
+    public void setBalloonNotification(boolean balloonNotification) {
+        myBalloonNotification = balloonNotification;
+    }
 
-  public @Nullable Navigatable getNavigatable() {
-    return navigatable;
-  }
+    public void setListener(String listenerId, NotificationListener listener) {
+        myListenerMap.put(listenerId, listener);
+    }
 
-  public void setNavigatable(@Nullable Navigatable navigatable) {
-    this.navigatable = navigatable;
-  }
+    public boolean hasLinks() {
+        return !myListenerMap.isEmpty();
+    }
+
+    public List<String> getRegisteredListenerIds() {
+        return new ArrayList<>(myListenerMap.keySet());
+    }
+
+    public @Nullable Navigable getNavigable() {
+        return myNavigable;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public @Nullable Navigatable getNavigatable() {
+        return (Navigatable) myNavigable;
+    }
+
+    public void setNavigable(@Nullable Navigable navigable) {
+        this.myNavigable = navigable;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #setNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public void setNavigatable(@Nullable Navigable navigable) {
+        this.myNavigable = navigable;
+    }
 }

--- a/modules/base/file-editor-api/src/main/java/consulo/fileEditor/NavigableFileEditor.java
+++ b/modules/base/file-editor-api/src/main/java/consulo/fileEditor/NavigableFileEditor.java
@@ -15,7 +15,6 @@
  */
 package consulo.fileEditor;
 
-import consulo.annotation.DeprecationInfo;
 import consulo.navigation.Navigable;
 
 /**
@@ -23,8 +22,20 @@ import consulo.navigation.Navigable;
  *
  * @author spleaner
  */
-@Deprecated
-@DeprecationInfo("Use NavigableFileEditor, typo-corrected name")
-@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
-public interface NavigatableFileEditor extends NavigableFileEditor {
+public interface NavigableFileEditor extends FileEditor {
+    /**
+     * Check whatever the editor can navigate to the given element
+     *
+     * @param navigable
+     * @return true if editor can navigate, false otherwise
+     */
+    boolean canNavigateTo(Navigable navigable);
+
+    /**
+     * Navigate editor to the given navigable if {@link #canNavigateTo(Navigable)} is true
+     *
+     * @param navigable navigation target
+     */
+    void navigateTo(Navigable navigable);
 }
+

--- a/modules/base/file-editor-impl/src/main/java/consulo/fileEditor/impl/internal/text/TextEditorImpl.java
+++ b/modules/base/file-editor-impl/src/main/java/consulo/fileEditor/impl/internal/text/TextEditorImpl.java
@@ -36,7 +36,7 @@ import consulo.fileEditor.structureView.StructureViewBuilder;
 import consulo.fileEditor.structureView.StructureViewBuilderProvider;
 import consulo.fileEditor.text.TextEditorState;
 import consulo.language.editor.highlight.EditorHighlighterFactory;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.OpenFileDescriptor;
 import consulo.project.Project;
 import consulo.ui.Component;
@@ -213,14 +213,14 @@ public class TextEditorImpl extends UserDataHolderBase implements RealTextEditor
     }
 
     @Override
-    public boolean canNavigateTo(Navigatable navigatable) {
-        return navigatable instanceof OpenFileDescriptor fileDescriptor
+    public boolean canNavigateTo(Navigable navigable) {
+        return navigable instanceof OpenFileDescriptor fileDescriptor
             && (fileDescriptor.getLine() != -1 || fileDescriptor.getOffset() >= 0);
     }
 
     @Override
-    public void navigateTo(Navigatable navigatable) {
-        ((OpenFileDescriptorImpl) navigatable).navigateIn(getEditor());
+    public void navigateTo(Navigable navigable) {
+        ((OpenFileDescriptorImpl) navigable).navigateIn(getEditor());
     }
 
     @Override

--- a/modules/base/file-editor-impl/src/main/java/consulo/fileEditor/impl/internal/text/TextEditorProviderImpl.java
+++ b/modules/base/file-editor-impl/src/main/java/consulo/fileEditor/impl/internal/text/TextEditorProviderImpl.java
@@ -26,7 +26,7 @@ import consulo.fileEditor.structureView.StructureViewBuilderProvider;
 import consulo.fileEditor.text.TextEditorProvider;
 import consulo.fileEditor.text.TextEditorState;
 import consulo.logging.Logger;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.ui.Component;
 import consulo.ui.annotation.RequiredUIAccess;
@@ -61,16 +61,14 @@ public class TextEditorProviderImpl extends TextEditorProvider {
         return isTextFile(file) && !RawFileLoaderHelper.isTooLargeForContentLoading(file);
     }
 
-    @RequiredUIAccess
     @Override
-    
+    @RequiredUIAccess
     public FileEditor createEditor(Project project, VirtualFile file) {
         LOG.assertTrue(accept(project, file));
         return new TextEditorImpl(project, file, this);
     }
 
     @Override
-    
     public TextEditor getTextEditor(Editor editor) {
         TextEditor textEditor = editor.getUserData(TEXT_EDITOR_KEY);
         if (textEditor == null) {
@@ -81,7 +79,6 @@ public class TextEditorProviderImpl extends TextEditorProvider {
         return textEditor;
     }
 
-    
     protected EditorWrapper createWrapperForEditor(Editor editor) {
         return new EditorWrapper(editor);
     }
@@ -148,13 +145,11 @@ public class TextEditorProviderImpl extends TextEditorProvider {
         }
 
         @Override
-        
         public Editor getEditor() {
             return myEditor;
         }
 
         @Override
-        
         public JComponent getComponent() {
             return myEditor.getComponent();
         }
@@ -256,12 +251,12 @@ public class TextEditorProviderImpl extends TextEditorProvider {
         }
 
         @Override
-        public boolean canNavigateTo(Navigatable navigatable) {
+        public boolean canNavigateTo(Navigable navigable) {
             return false;
         }
 
         @Override
-        public void navigateTo(Navigatable navigatable) {
+        public void navigateTo(Navigable navigable) {
         }
     }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/compiler/ProblemsViewImpl.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/compiler/ProblemsViewImpl.java
@@ -20,7 +20,7 @@ import consulo.application.util.concurrent.SequentialTaskExecutor;
 import consulo.compiler.ProblemsView;
 import consulo.ide.impl.idea.ide.errorTreeView.impl.ErrorTreeViewConfiguration;
 import consulo.logging.Logger;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.ui.view.MessageView;
 import consulo.ui.annotation.RequiredUIAccess;
@@ -50,28 +50,28 @@ public class ProblemsViewImpl extends ProblemsView {
     public static final Logger LOGGER = Logger.getInstance(ProblemsViewImpl.class);
 
     private static class TempMessage {
-        final int type;
+        final int myType;
         
-        final String[] text;
-        final @Nullable String groupName;
-        final @Nullable Navigatable navigatable;
-        final @Nullable String exportTextPrefix;
-        final @Nullable String rendererTextPrefix;
+        final String[] myText;
+        final @Nullable String myGroupName;
+        final @Nullable Navigable myNavigable;
+        final @Nullable String myExportTextPrefix;
+        final @Nullable String myRendererTextPrefix;
 
         private TempMessage(
             int type,
             String[] text,
             @Nullable String groupName,
-            @Nullable Navigatable navigatable,
+            @Nullable Navigable navigable,
             @Nullable String exportTextPrefix,
             @Nullable String rendererTextPrefix
         ) {
-            this.type = type;
-            this.text = text;
-            this.groupName = groupName;
-            this.navigatable = navigatable;
-            this.exportTextPrefix = exportTextPrefix;
-            this.rendererTextPrefix = rendererTextPrefix;
+            this.myType = type;
+            this.myText = text;
+            this.myGroupName = groupName;
+            this.myNavigable = navigable;
+            this.myExportTextPrefix = exportTextPrefix;
+            this.myRendererTextPrefix = rendererTextPrefix;
         }
     }
 
@@ -107,11 +107,11 @@ public class ProblemsViewImpl extends ProblemsView {
         int type,
         String[] text,
         @Nullable String groupName,
-        @Nullable Navigatable navigatable,
+        @Nullable Navigable navigable,
         @Nullable String exportTextPrefix,
         @Nullable String rendererTextPrefix
     ) {
-        TempMessage message = new TempMessage(type, text, groupName, navigatable, exportTextPrefix, rendererTextPrefix);
+        TempMessage message = new TempMessage(type, text, groupName, navigable, exportTextPrefix, rendererTextPrefix);
 
         myTempMessages.add(message);
 
@@ -121,11 +121,11 @@ public class ProblemsViewImpl extends ProblemsView {
         }
     }
 
-    @RequiredUIAccess
     @Override
+    @RequiredUIAccess
     public void showOrHide(boolean hide) {
         ToolWindow toolWindow = MessageView.getInstance(myProject).getToolWindow();
-        // dont try hide if toolwindow closed
+        // Don't try hide if toolwindow closed
         if (hide && !toolWindow.isVisible()) {
             return;
         }
@@ -160,19 +160,19 @@ public class ProblemsViewImpl extends ProblemsView {
     }
 
     private static void addMessage(ProblemsViewPanel problemsViewPanel, TempMessage tempMessage) {
-        if (tempMessage.navigatable != null) {
+        if (tempMessage.myNavigable != null) {
             problemsViewPanel.addMessage(
-                tempMessage.type,
-                tempMessage.text,
-                tempMessage.groupName,
-                tempMessage.navigatable,
-                tempMessage.exportTextPrefix,
-                tempMessage.rendererTextPrefix,
+                tempMessage.myType,
+                tempMessage.myText,
+                tempMessage.myGroupName,
+                tempMessage.myNavigable,
+                tempMessage.myExportTextPrefix,
+                tempMessage.myRendererTextPrefix,
                 null
             );
         }
         else {
-            problemsViewPanel.addMessage(tempMessage.type, tempMessage.text, null, -1, -1, null);
+            problemsViewPanel.addMessage(tempMessage.myType, tempMessage.myText, null, -1, -1, null);
         }
     }
 

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/externalSystem/EditableNotificationMessageElement.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/externalSystem/EditableNotificationMessageElement.java
@@ -16,16 +16,16 @@
 package consulo.ide.impl.externalSystem;
 
 import consulo.ide.impl.idea.ide.IdeTooltipManagerImpl;
-import consulo.ide.impl.idea.ide.errorTreeView.*;
+import consulo.ide.impl.idea.ide.errorTreeView.EditableMessageElement;
+import consulo.ide.impl.idea.ide.errorTreeView.GroupingElement;
+import consulo.navigation.Navigable;
 import consulo.project.ui.notification.Notification;
 import consulo.project.ui.notification.event.NotificationListener;
-import consulo.navigation.Navigatable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.*;
 import consulo.ui.ex.awt.PopupHandler;
 import consulo.ui.ex.awt.UIUtil;
 import consulo.ui.ex.errorTreeView.ErrorTreeElementKind;
-
 import org.jspecify.annotations.Nullable;
 
 import javax.swing.*;
@@ -48,150 +48,149 @@ import java.util.Map;
  * @since 2014-03-24
  */
 public class EditableNotificationMessageElement extends NotificationMessageElement implements EditableMessageElement {
+    private final TreeCellEditor myRightTreeCellEditor;
 
-  
-  private final TreeCellEditor myRightTreeCellEditor;
-  
-  private final Notification myNotification;
-  
-  private final Map<String/*url*/, String/*link text to replace*/> disabledLinks;
+    private final Notification myNotification;
 
-  public EditableNotificationMessageElement(
-    Notification notification,
-    ErrorTreeElementKind kind,
-    @Nullable GroupingElement parent,
-    String[] message,
-    Navigatable navigatable,
-    String exportText, String rendererTextPrefix
-  ) {
-    super(kind, parent, message, navigatable, exportText, rendererTextPrefix);
-    myNotification = notification;
-    disabledLinks = new HashMap<>();
-    myRightTreeCellEditor = new MyCellEditor();
-  }
+    private final Map<String/*url*/, String/*link text to replace*/> disabledLinks;
 
-  public void addDisabledLink(String url, @Nullable String text) {
-    disabledLinks.put(url, text);
-  }
-
-  
-  @Override
-  public TreeCellEditor getRightSelfEditor() {
-    return myRightTreeCellEditor;
-  }
-
-  @Override
-  public boolean startEditingOnMouseMove() {
-    return true;
-  }
-
-  public static void disableLink(HyperlinkEvent event) {
-    disableLink(event, null);
-  }
-
-  private static void disableLink(HyperlinkEvent event, @Nullable String linkText) {
-    if (event.getSource() instanceof MyJEditorPane editorPane) {
-      UIUtil.invokeLaterIfNeeded(() -> {
-        editorPane.myElement.addDisabledLink(event.getDescription(), linkText);
-        editorPane.myElement.updateStyle(editorPane, null, null, true, false);
-      });
+    public EditableNotificationMessageElement(
+        Notification notification,
+        ErrorTreeElementKind kind,
+        @Nullable GroupingElement parent,
+        String[] message,
+        Navigable navigable,
+        String exportText, String rendererTextPrefix
+    ) {
+        super(kind, parent, message, navigable, exportText, rendererTextPrefix);
+        myNotification = notification;
+        disabledLinks = new HashMap<>();
+        myRightTreeCellEditor = new MyCellEditor();
     }
-  }
 
-  @Override
-  protected void updateStyle(JEditorPane editorPane, @Nullable JTree tree, Object value, boolean selected, boolean hasFocus) {
-    super.updateStyle(editorPane, tree, value, selected, hasFocus);
+    public void addDisabledLink(String url, @Nullable String text) {
+        disabledLinks.put(url, text);
+    }
 
-    HTMLDocument htmlDocument = (HTMLDocument)editorPane.getDocument();
-    Style linkStyle = htmlDocument.getStyleSheet().getStyle(NotificationMessageElement.LINK_STYLE);
-    StyleConstants.setForeground(linkStyle, IdeTooltipManagerImpl.getInstanceImpl().getLinkForeground(false));
-    StyleConstants.setItalic(linkStyle, true);
-    HTMLDocument.Iterator iterator = htmlDocument.getIterator(HTML.Tag.A);
-    while (iterator.isValid()) {
-      boolean disabledLink = false;
-      AttributeSet attributes = iterator.getAttributes();
-      if (attributes instanceof SimpleAttributeSet simpleAttributeSet) {
-        Object attribute = attributes.getAttribute(HTML.Attribute.HREF);
-        if (attribute instanceof String && disabledLinks.containsKey(attribute)) {
-          disabledLink = true;
-          //TODO [Vlad] add support for disabled link text update
-          ////final String linkText = disabledLinks.get(attribute);
-          //if (linkText != null) {
-          //}
-          simpleAttributeSet.removeAttribute(HTML.Attribute.HREF);
+    @Override
+    public TreeCellEditor getRightSelfEditor() {
+        return myRightTreeCellEditor;
+    }
+
+    @Override
+    public boolean startEditingOnMouseMove() {
+        return true;
+    }
+
+    public static void disableLink(HyperlinkEvent event) {
+        disableLink(event, null);
+    }
+
+    private static void disableLink(HyperlinkEvent event, @Nullable String linkText) {
+        if (event.getSource() instanceof MyJEditorPane editorPane) {
+            UIUtil.invokeLaterIfNeeded(() -> {
+                editorPane.myElement.addDisabledLink(event.getDescription(), linkText);
+                editorPane.myElement.updateStyle(editorPane, null, null, true, false);
+            });
         }
-        if (attribute == null) {
-          disabledLink = true;
+    }
+
+    @Override
+    protected void updateStyle(JEditorPane editorPane, @Nullable JTree tree, Object value, boolean selected, boolean hasFocus) {
+        super.updateStyle(editorPane, tree, value, selected, hasFocus);
+
+        HTMLDocument htmlDocument = (HTMLDocument) editorPane.getDocument();
+        Style linkStyle = htmlDocument.getStyleSheet().getStyle(NotificationMessageElement.LINK_STYLE);
+        StyleConstants.setForeground(linkStyle, IdeTooltipManagerImpl.getInstanceImpl().getLinkForeground(false));
+        StyleConstants.setItalic(linkStyle, true);
+        HTMLDocument.Iterator iterator = htmlDocument.getIterator(HTML.Tag.A);
+        while (iterator.isValid()) {
+            boolean disabledLink = false;
+            AttributeSet attributes = iterator.getAttributes();
+            if (attributes instanceof SimpleAttributeSet simpleAttributeSet) {
+                Object attribute = attributes.getAttribute(HTML.Attribute.HREF);
+                if (attribute instanceof String && disabledLinks.containsKey(attribute)) {
+                    disabledLink = true;
+                    //TODO [Vlad] add support for disabled link text update
+                    ////final String linkText = disabledLinks.get(attribute);
+                    //if (linkText != null) {
+                    //}
+                    simpleAttributeSet.removeAttribute(HTML.Attribute.HREF);
+                }
+                if (attribute == null) {
+                    disabledLink = true;
+                }
+            }
+            if (!disabledLink) {
+                htmlDocument.setCharacterAttributes(
+                    iterator.getStartOffset(), iterator.getEndOffset() - iterator.getStartOffset(), linkStyle, false);
+            }
+            iterator.next();
         }
-      }
-      if (!disabledLink) {
-        htmlDocument.setCharacterAttributes(
-                iterator.getStartOffset(), iterator.getEndOffset() - iterator.getStartOffset(), linkStyle, false);
-      }
-      iterator.next();
     }
-  }
 
-  private static class MyJEditorPane extends JEditorPane {
-    
-    private final EditableNotificationMessageElement myElement;
+    private static class MyJEditorPane extends JEditorPane {
 
-    public MyJEditorPane(EditableNotificationMessageElement element) {
-      myElement = element;
+        private final EditableNotificationMessageElement myElement;
+
+        public MyJEditorPane(EditableNotificationMessageElement element) {
+            myElement = element;
+        }
     }
-  }
 
-  private class MyCellEditor extends AbstractCellEditor implements TreeCellEditor {
-    private final JEditorPane editorComponent;
-    private @Nullable JTree myTree;
+    private class MyCellEditor extends AbstractCellEditor implements TreeCellEditor {
+        private final JEditorPane editorComponent;
+        private @Nullable JTree myTree;
 
-    private MyCellEditor() {
-      editorComponent = installJep(new MyJEditorPane(EditableNotificationMessageElement.this));
+        private MyCellEditor() {
+            editorComponent = installJep(new MyJEditorPane(EditableNotificationMessageElement.this));
 
-      HyperlinkListener hyperlinkListener = new ActivatedHyperlinkListener();
-      editorComponent.addHyperlinkListener(hyperlinkListener);
-      editorComponent.addMouseListener(new PopupHandler() {
+            HyperlinkListener hyperlinkListener = new ActivatedHyperlinkListener();
+            editorComponent.addHyperlinkListener(hyperlinkListener);
+            editorComponent.addMouseListener(new PopupHandler() {
+                @Override
+                public void invokePopup(Component comp, int x, int y) {
+                    if (myTree == null) {
+                        return;
+                    }
+
+                    TreePath path = myTree.getLeadSelectionPath();
+                    if (path == null) {
+                        return;
+                    }
+                    DefaultActionGroup group = new DefaultActionGroup();
+                    group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_EDIT_SOURCE));
+                    group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_COPY));
+
+                    ActionPopupMenu menu = ActionManager.getInstance().createActionPopupMenu(ActionPlaces.COMPILER_MESSAGES_POPUP, group);
+                    menu.getComponent().show(comp, x, y);
+                }
+            });
+        }
+
         @Override
-        public void invokePopup(Component comp, int x, int y) {
-          if (myTree == null) return;
-
-          TreePath path = myTree.getLeadSelectionPath();
-          if (path == null) {
-            return;
-          }
-          DefaultActionGroup group = new DefaultActionGroup();
-          group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_EDIT_SOURCE));
-          group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_COPY));
-
-          ActionPopupMenu menu = ActionManager.getInstance().createActionPopupMenu(ActionPlaces.COMPILER_MESSAGES_POPUP, group);
-          menu.getComponent().show(comp, x, y);
+        public Component getTreeCellEditorComponent(JTree tree, Object value, boolean selected, boolean expanded, boolean leaf, int row) {
+            myTree = tree;
+            updateStyle(editorComponent, tree, value, selected, false);
+            return editorComponent;
         }
-      });
-    }
 
-    @Override
-    public Component getTreeCellEditorComponent(JTree tree, Object value, boolean selected, boolean expanded, boolean leaf, int row) {
-      myTree = tree;
-      updateStyle(editorComponent, tree, value, selected, false);
-      return editorComponent;
-    }
-
-    @Override
-    public Object getCellEditorValue() {
-      return null;
-    }
-
-    private class ActivatedHyperlinkListener implements HyperlinkListener {
-      @Override
-      @RequiredUIAccess
-      public void hyperlinkUpdate(HyperlinkEvent e) {
-        if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-          NotificationListener notificationListener = myNotification.getListener();
-          if (notificationListener != null) {
-            notificationListener.hyperlinkUpdate(myNotification, e);
-          }
+        @Override
+        public Object getCellEditorValue() {
+            return null;
         }
-      }
+
+        private class ActivatedHyperlinkListener implements HyperlinkListener {
+            @Override
+            @RequiredUIAccess
+            public void hyperlinkUpdate(HyperlinkEvent e) {
+                if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                    NotificationListener notificationListener = myNotification.getListener();
+                    if (notificationListener != null) {
+                        notificationListener.hyperlinkUpdate(myNotification, e);
+                    }
+                }
+            }
+        }
     }
-  }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/externalSystem/ExternalSystemInternalNotificationHelperImpl.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/externalSystem/ExternalSystemInternalNotificationHelperImpl.java
@@ -26,10 +26,10 @@ import consulo.externalSystem.service.notification.NotificationSource;
 import consulo.fileEditor.impl.internal.OpenFileDescriptorImpl;
 import consulo.ide.ServiceManager;
 import consulo.ide.impl.idea.ide.errorTreeView.GroupingElement;
-import consulo.ide.impl.idea.ide.errorTreeView.NavigatableMessageElement;
+import consulo.ide.impl.idea.ide.errorTreeView.NavigableMessageElement;
 import consulo.ide.impl.idea.ide.errorTreeView.NewEditableErrorTreeViewPanel;
 import consulo.ide.impl.idea.ide.errorTreeView.NewErrorTreeViewPanelImpl;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.ui.notification.Notification;
 import consulo.project.ui.view.MessageView;
@@ -45,9 +45,9 @@ import consulo.ui.ex.toolWindow.ToolWindow;
 import consulo.util.lang.Pair;
 import consulo.util.lang.StringUtil;
 import consulo.virtualFileSystem.VirtualFile;
-import org.jspecify.annotations.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author VISTALL
@@ -79,8 +79,8 @@ public class ExternalSystemInternalNotificationHelperImpl implements ExternalSys
         int guiLine = line < 0 ? -1 : line + 1;
         int guiColumn = column < 0 ? 0 : column + 1;
 
-        Navigatable navigatable = notificationData.getNavigatable() != null
-            ? notificationData.getNavigatable()
+        Navigable navigable = notificationData.getNavigable() != null
+            ? notificationData.getNavigable()
             : virtualFile != null ? new OpenFileDescriptorImpl(myProject, virtualFile, line, column) : null;
 
         ErrorTreeElementKind kind =
@@ -96,35 +96,34 @@ public class ExternalSystemInternalNotificationHelperImpl implements ExternalSys
             NewErrorTreeViewPanelImpl errorTreeView =
                 prepareMessagesView(externalSystemId, notificationData.getNotificationSource(), activate);
             GroupingElement groupingElement = errorTreeView.getErrorViewStructure().getGroupingElement(groupName, null, virtualFile);
-            NavigatableMessageElement navigatableMessageElement;
+            NavigableMessageElement navigableMessageElement;
             if (notificationData.hasLinks()) {
-                navigatableMessageElement = new EditableNotificationMessageElement(
+                navigableMessageElement = new EditableNotificationMessageElement(
                     notification,
                     kind,
                     groupingElement,
                     message,
-                    navigatable,
+                    navigable,
                     exportPrefix,
                     rendererPrefix
                 );
             }
             else {
-                navigatableMessageElement = new NotificationMessageElement(
+                navigableMessageElement = new NotificationMessageElement(
                     kind,
                     groupingElement,
                     message,
-                    navigatable,
+                    navigable,
                     exportPrefix,
                     rendererPrefix
                 );
             }
 
-            errorTreeView.getErrorViewStructure().addNavigatableMessage(groupName, navigatableMessageElement);
+            errorTreeView.getErrorViewStructure().addNavigableMessage(groupName, navigableMessageElement);
             errorTreeView.updateTree();
         });
     }
 
-    
     @RequiredUIAccess
     public NewErrorTreeViewPanelImpl prepareMessagesView(
         ProjectSystemId externalSystemId,
@@ -172,11 +171,7 @@ public class ExternalSystemInternalNotificationHelperImpl implements ExternalSys
         return targetContent;
     }
 
-    
-    public static String getContentDisplayName(
-        NotificationSource notificationSource,
-        ProjectSystemId externalSystemId
-    ) {
+    public static String getContentDisplayName(NotificationSource notificationSource, ProjectSystemId externalSystemId) {
         if (notificationSource != NotificationSource.PROJECT_SYNC) {
             throw new AssertionError("unsupported notification source found: " + notificationSource);
         }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/externalSystem/NotificationMessageElement.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/externalSystem/NotificationMessageElement.java
@@ -20,7 +20,7 @@ import consulo.ide.impl.idea.ide.errorTreeView.GroupingElement;
 import consulo.ide.impl.idea.ide.errorTreeView.NavigatableMessageElement;
 import consulo.ide.impl.idea.ide.errorTreeView.NewErrorTreeRenderer;
 import consulo.ide.impl.idea.ui.CustomizeColoredTreeCellRenderer;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.ui.ex.JBColor;
 import consulo.ui.ex.awt.JBHtmlEditorKit;
@@ -44,125 +44,130 @@ import java.awt.*;
  * @since 2014-03-24
  */
 public class NotificationMessageElement extends NavigatableMessageElement {
-  public static final String MSG_STYLE = "messageStyle";
-  public static final String LINK_STYLE = "linkStyle";
+    public static final String MSG_STYLE = "messageStyle";
+    public static final String LINK_STYLE = "linkStyle";
 
-  
-  private final CustomizeColoredTreeCellRenderer myLeftTreeCellRenderer;
-  
-  private final CustomizeColoredTreeCellRenderer myRightTreeCellRenderer;
+    private final CustomizeColoredTreeCellRenderer myLeftTreeCellRenderer;
 
-  public NotificationMessageElement(final ErrorTreeElementKind kind,
-                                    @Nullable GroupingElement parent,
-                                    String[] message,
-                                    Navigatable navigatable,
-                                    String exportText,
-                                    String rendererTextPrefix) {
-    super(kind, parent, message, navigatable, exportText, rendererTextPrefix);
-    myLeftTreeCellRenderer = new CustomizeColoredTreeCellRenderer() {
-      @Override
-      public void customizeCellRenderer(SimpleColoredComponent renderer,
-                                        JTree tree,
-                                        Object value,
-                                        boolean selected,
-                                        boolean expanded,
-                                        boolean leaf,
-                                        int row,
-                                        boolean hasFocus) {
-        renderer.setIcon(getIcon(kind));
-        renderer.setFont(tree.getFont());
-        renderer.append(NewErrorTreeRenderer.calcPrefix(NotificationMessageElement.this));
-      }
+    private final CustomizeColoredTreeCellRenderer myRightTreeCellRenderer;
 
-      
-      private Image getIcon(ErrorTreeElementKind kind) {
-        Image icon = Image.empty(Image.DEFAULT_ICON_SIZE);
-        switch (kind) {
-          case INFO:
-            icon = PlatformIconGroup.generalInformation();
-            break;
-          case ERROR:
-            icon = PlatformIconGroup.generalError();
-            break;
-          case WARNING:
-            icon = PlatformIconGroup.generalWarning();
-            break;
-          case NOTE:
-            icon = PlatformIconGroup.actionsIntentionbulb();
-            break;
-          case GENERIC:
-            break;
-        }
-        return icon;
-      }
-    };
+    public NotificationMessageElement(
+        final ErrorTreeElementKind kind,
+        @Nullable GroupingElement parent,
+        String[] message,
+        Navigable navigable,
+        String exportText,
+        String rendererTextPrefix
+    ) {
+        super(kind, parent, message, navigable, exportText, rendererTextPrefix);
+        myLeftTreeCellRenderer = new CustomizeColoredTreeCellRenderer() {
+            @Override
+            public void customizeCellRenderer(
+                SimpleColoredComponent renderer,
+                JTree tree,
+                Object value,
+                boolean selected,
+                boolean expanded,
+                boolean leaf,
+                int row,
+                boolean hasFocus
+            ) {
+                renderer.setIcon(getIcon(kind));
+                renderer.setFont(tree.getFont());
+                renderer.append(NewErrorTreeRenderer.calcPrefix(NotificationMessageElement.this));
+            }
 
-    myRightTreeCellRenderer = new MyCustomizeColoredTreeCellRendererReplacement();
-  }
 
-  @Override
-  public @Nullable CustomizeColoredTreeCellRenderer getRightSelfRenderer() {
-    return myRightTreeCellRenderer;
-  }
+            private Image getIcon(ErrorTreeElementKind kind) {
+                Image icon = Image.empty(Image.DEFAULT_ICON_SIZE);
+                switch (kind) {
+                    case INFO:
+                        icon = PlatformIconGroup.generalInformation();
+                        break;
+                    case ERROR:
+                        icon = PlatformIconGroup.generalError();
+                        break;
+                    case WARNING:
+                        icon = PlatformIconGroup.generalWarning();
+                        break;
+                    case NOTE:
+                        icon = PlatformIconGroup.actionsIntentionbulb();
+                        break;
+                    case GENERIC:
+                        break;
+                }
+                return icon;
+            }
+        };
 
-  @Override
-  public @Nullable CustomizeColoredTreeCellRenderer getLeftSelfRenderer() {
-    return myLeftTreeCellRenderer;
-  }
-
-  protected JEditorPane installJep(JEditorPane myEditorPane) {
-    String message = StringUtil.join(this.getText(), "<br>");
-    myEditorPane.setEditable(false);
-    myEditorPane.setOpaque(false);
-    myEditorPane.setEditorKit(JBHtmlEditorKit.create());
-    myEditorPane.setHighlighter(null);
-
-    StyleSheet styleSheet = ((HTMLDocument)myEditorPane.getDocument()).getStyleSheet();
-    Style style = styleSheet.addStyle(MSG_STYLE, null);
-    styleSheet.addStyle(LINK_STYLE, style);
-    myEditorPane.setText(message);
-
-    return myEditorPane;
-  }
-
-  protected void updateStyle(JEditorPane editorPane, @Nullable JTree tree, Object value, boolean selected, boolean hasFocus) {
-    HTMLDocument htmlDocument = (HTMLDocument)editorPane.getDocument();
-    Style style = htmlDocument.getStyleSheet().getStyle(MSG_STYLE);
-    if (value instanceof LoadingNode) {
-      StyleConstants.setForeground(style, JBColor.GRAY);
-    }
-    else {
-      if (selected) {
-        StyleConstants.setForeground(style, hasFocus ? UIUtil.getTreeSelectionForeground() : UIUtil.getTreeTextForeground());
-      }
-      else {
-        StyleConstants.setForeground(style, UIUtil.getTreeTextForeground());
-      }
-    }
-
-    editorPane.setOpaque(false);
-
-    htmlDocument.setCharacterAttributes(0, htmlDocument.getLength(), style, false);
-  }
-
-  private class MyCustomizeColoredTreeCellRendererReplacement extends CustomizeColoredTreeCellRendererReplacement {
-    
-    private final JEditorPane myEditorPane;
-
-    private MyCustomizeColoredTreeCellRendererReplacement() {
-      myEditorPane = installJep(new JEditorPane());
+        myRightTreeCellRenderer = new MyCustomizeColoredTreeCellRendererReplacement();
     }
 
     @Override
-    public Component getTreeCellRendererComponent(JTree tree,
-                                                  Object value,
-                                                  boolean selected,
-                                                  boolean expanded,
-                                                  boolean leaf,
-                                                  int row,
-                                                  boolean hasFocus) {
-      updateStyle(myEditorPane, tree, value, selected, hasFocus);
-      return myEditorPane;
+    public @Nullable CustomizeColoredTreeCellRenderer getRightSelfRenderer() {
+        return myRightTreeCellRenderer;
     }
-  }
+
+    @Override
+    public @Nullable CustomizeColoredTreeCellRenderer getLeftSelfRenderer() {
+        return myLeftTreeCellRenderer;
+    }
+
+    protected JEditorPane installJep(JEditorPane myEditorPane) {
+        String message = StringUtil.join(this.getText(), "<br>");
+        myEditorPane.setEditable(false);
+        myEditorPane.setOpaque(false);
+        myEditorPane.setEditorKit(JBHtmlEditorKit.create());
+        myEditorPane.setHighlighter(null);
+
+        StyleSheet styleSheet = ((HTMLDocument) myEditorPane.getDocument()).getStyleSheet();
+        Style style = styleSheet.addStyle(MSG_STYLE, null);
+        styleSheet.addStyle(LINK_STYLE, style);
+        myEditorPane.setText(message);
+
+        return myEditorPane;
+    }
+
+    protected void updateStyle(JEditorPane editorPane, @Nullable JTree tree, Object value, boolean selected, boolean hasFocus) {
+        HTMLDocument htmlDocument = (HTMLDocument) editorPane.getDocument();
+        Style style = htmlDocument.getStyleSheet().getStyle(MSG_STYLE);
+        if (value instanceof LoadingNode) {
+            StyleConstants.setForeground(style, JBColor.GRAY);
+        }
+        else {
+            if (selected) {
+                StyleConstants.setForeground(style, hasFocus ? UIUtil.getTreeSelectionForeground() : UIUtil.getTreeTextForeground());
+            }
+            else {
+                StyleConstants.setForeground(style, UIUtil.getTreeTextForeground());
+            }
+        }
+
+        editorPane.setOpaque(false);
+
+        htmlDocument.setCharacterAttributes(0, htmlDocument.getLength(), style, false);
+    }
+
+    private class MyCustomizeColoredTreeCellRendererReplacement extends CustomizeColoredTreeCellRendererReplacement {
+
+        private final JEditorPane myEditorPane;
+
+        private MyCustomizeColoredTreeCellRendererReplacement() {
+            myEditorPane = installJep(new JEditorPane());
+        }
+
+        @Override
+        public Component getTreeCellRendererComponent(
+            JTree tree,
+            Object value,
+            boolean selected,
+            boolean expanded,
+            boolean leaf,
+            int row,
+            boolean hasFocus
+        ) {
+            updateStyle(myEditorPane, tree, value, selected, hasFocus);
+            return myEditorPane;
+        }
+    }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/build/ExecutionNodeImpl.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/build/ExecutionNodeImpl.java
@@ -1,11 +1,12 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package consulo.ide.impl.idea.build;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.application.util.NullableLazyValue;
 import consulo.build.ui.ExecutionNode;
 import consulo.build.ui.event.*;
 import consulo.build.ui.localize.BuildLocalize;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.project.Project;
 import consulo.ui.ex.SimpleTextAttributes;
@@ -53,7 +54,7 @@ public class ExecutionNodeImpl extends ExecutionNode<ExecutionNodeImpl> {
     private volatile @Nullable EventResult myResult;
     private final boolean myAutoExpandNode;
     private final Supplier<Boolean> myIsCorrectThread;
-    private volatile @Nullable Navigatable myNavigatable;
+    private volatile @Nullable Navigable myNavigable;
     private volatile @Nullable NullableLazyValue<Image> myPreferredIconValue;
     private Predicate<? super ExecutionNodeImpl> myFilter;
     private boolean myAlwaysLeaf;
@@ -304,25 +305,31 @@ public class ExecutionNodeImpl extends ExecutionNode<ExecutionNodeImpl> {
         myAlwaysLeaf = alwaysLeaf;
     }
 
-    public void setNavigatable(@Nullable Navigatable navigatable) {
+    @Deprecated
+    @DeprecationInfo("Use #setNavigable() with typo-fixed name")
+    @SuppressWarnings("SpellCheckingInspection")
+    public void setNavigatable(@Nullable Navigable navigable) {
+        setNavigable(navigable);
+    }
+
+    public void setNavigable(@Nullable Navigable navigable) {
         assert myIsCorrectThread.get();
-        myNavigatable = navigatable;
+        myNavigable = navigable;
     }
 
     @Override
-   
-    public List<Navigatable> getNavigatables() {
-        if (myNavigatable != null) {
-            return Collections.singletonList(myNavigatable);
+    public List<Navigable> getNavigables() {
+        if (myNavigable != null) {
+            return Collections.singletonList(myNavigable);
         }
         if (myResult == null) {
             return Collections.emptyList();
         }
 
         if (myResult instanceof FailureResult failureResult) {
-            List<Navigatable> result = new SmartList<>();
+            List<Navigable> result = new SmartList<>();
             for (Failure failure : failureResult.getFailures()) {
-                ContainerUtil.addIfNotNull(result, failure.getNavigatable());
+                ContainerUtil.addIfNotNull(result, failure.getNavigable());
             }
             return result;
         }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/codeInsight/navigation/CtrlMouseHandler.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/codeInsight/navigation/CtrlMouseHandler.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package consulo.ide.impl.idea.codeInsight.navigation;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.annotation.access.RequiredReadAction;
 import consulo.annotation.component.ComponentScope;
 import consulo.annotation.component.ServiceAPI;
@@ -47,7 +48,7 @@ import consulo.language.psi.search.DefinitionsScopedSearch;
 import consulo.language.psi.util.EditSourceUtil;
 import consulo.logging.Logger;
 import consulo.navigation.ItemPresentation;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.NavigationItem;
 import consulo.project.DumbService;
 import consulo.project.Project;
@@ -370,7 +371,14 @@ public final class CtrlMouseHandler {
 
         public abstract boolean isValid(Document document);
 
-        public abstract boolean isNavigatable();
+        public abstract boolean isNavigable();
+
+        @Deprecated
+        @DeprecationInfo("Use #isNavigable(), typo-corrected name")
+        @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+        public final boolean isNavigatable() {
+            return isNavigable();
+        }
 
         boolean rangesAreCorrect(Document document) {
             TextRange docRange = new TextRange(0, document.getTextLength());
@@ -405,7 +413,7 @@ public final class CtrlMouseHandler {
 
         @Override
         public DocInfo getInfo() {
-            return areElementsValid() ? generateInfo(myTargetElement, myElementAtPointer, isNavigatable()) : DocInfo.EMPTY;
+            return areElementsValid() ? generateInfo(myTargetElement, myElementAtPointer, isNavigable()) : DocInfo.EMPTY;
         }
 
         @RequiredReadAction
@@ -414,12 +422,13 @@ public final class CtrlMouseHandler {
         }
 
         @Override
+        @RequiredReadAction
         public boolean isValid(Document document) {
             return areElementsValid() && rangesAreCorrect(document);
         }
 
         @Override
-        public boolean isNavigatable() {
+        public boolean isNavigable() {
             return myTargetElement != myElementAtPointer && myTargetElement != myElementAtPointer.getParent();
         }
     }
@@ -445,7 +454,7 @@ public final class CtrlMouseHandler {
         }
 
         @Override
-        public boolean isNavigatable() {
+        public boolean isNavigable() {
             return true;
         }
     }
@@ -521,7 +530,7 @@ public final class CtrlMouseHandler {
                 return null;
             }
             if (targetElements.length == 1) {
-                Navigatable descriptor = EditSourceUtil.getDescriptor(targetElements[0]);
+                Navigable descriptor = EditSourceUtil.getDescriptor(targetElements[0]);
                 if (descriptor == null || !descriptor.canNavigate()) {
                     return null;
                 }
@@ -544,7 +553,6 @@ public final class CtrlMouseHandler {
 
                 if (baseDocInfo != DocInfo.EMPTY && !StringUtil.isEmptyOrSpaces(baseDocInfo.text)) {
                     return new Info(identifier) {
-                        
                         @Override
                         public DocInfo getInfo() {
                             StringBuilder builder = new StringBuilder("<small>Show usages of </small><br>");
@@ -558,14 +566,13 @@ public final class CtrlMouseHandler {
                         }
 
                         @Override
-                        public boolean isNavigatable() {
+                        public boolean isNavigable() {
                             return true;
                         }
                     };
                 }
                 else {
                     return new Info(identifier) {
-                        
                         @Override
                         public DocInfo getInfo() {
                             String name = UsageViewUtil.getType(element) + " '" + UsageViewUtil.getShortName(element) + "'";
@@ -573,12 +580,13 @@ public final class CtrlMouseHandler {
                         }
 
                         @Override
+                        @RequiredReadAction
                         public boolean isValid(Document document) {
                             return element.isValid();
                         }
 
                         @Override
-                        public boolean isNavigatable() {
+                        public boolean isNavigable() {
                             return true;
                         }
                     };
@@ -606,6 +614,7 @@ public final class CtrlMouseHandler {
         return resolvedElement == null ? Collections.emptyList() : Collections.singletonList(resolvedElement);
     }
 
+    @RequiredUIAccess
     public void disposeHighlighter() {
         HighlightersSet highlighter = myHighlighter;
         if (highlighter != null) {
@@ -698,6 +707,7 @@ public final class CtrlMouseHandler {
             return myBrowseMode;
         }
 
+        @RequiredUIAccess
         void execute(BrowseMode browseMode) {
             myBrowseMode = browseMode;
 
@@ -724,6 +734,7 @@ public final class CtrlMouseHandler {
             return CtrlMouseHandler.this::disposeHighlighter;
         }
 
+        @RequiredReadAction
         private Runnable doExecute() {
             EditorEx editor = getPossiblyInjectedEditor();
             int offset = getOffset(editor);
@@ -768,6 +779,7 @@ public final class CtrlMouseHandler {
             return editor instanceof EditorWindow ? ((EditorWindow) editor).getDocument().hostToInjected(myHostOffset) : myHostOffset;
         }
 
+        @RequiredUIAccess
         private void addHighlighterAndShowHint(Info info, DocInfo docInfo, EditorEx editor) {
             if (myDisposed || editor.isDisposed()) {
                 return;
@@ -778,14 +790,14 @@ public final class CtrlMouseHandler {
                 }
                 else {
                     // highlighter already set
-                    if (info.isNavigatable()) {
+                    if (info.isNavigable()) {
                         editor.setCustomCursor(CtrlMouseHandler.class, Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
                     }
                     return;
                 }
             }
 
-            if (!info.isValid(editor.getDocument()) || !info.isNavigatable() && docInfo.text == null) {
+            if (!info.isValid(editor.getDocument()) || !info.isNavigable() && docInfo.text == null) {
                 return;
             }
 
@@ -815,7 +827,6 @@ public final class CtrlMouseHandler {
             }
         }
 
-        
         private JComponent wrapInScrollPaneIfNeeded(JComponent component, Editor editor) {
             if (!ApplicationManager.getApplication().isHeadlessEnvironment()) {
                 Dimension preferredSize = component.getPreferredSize();
@@ -842,21 +853,29 @@ public final class CtrlMouseHandler {
             }
             Disposable hintDisposable = Disposable.newDisposable("CtrlMouseHandler.TooltipProvider.updateOnPsiChanges");
             hint.addHintListener(__ -> Disposer.dispose(hintDisposable));
-            myProject.getMessageBus().connect(hintDisposable).subscribe(PsiModificationTrackerListener.class, () -> ReadAction.nonBlocking(() -> {
-                    try {
-                        DocInfo newDocInfo = info.getInfo();
-                        return (Runnable) () -> {
-                            if (newDocInfo.text != null && !oldText.equals(newDocInfo.text)) {
-                                updateText(newDocInfo.text, textConsumer, hint, editor);
-                            }
-                        };
-                    }
-                    catch (IndexNotReadyException e) {
-                        showDumbModeNotification(myProject);
-                        return createDisposalContinuation();
-                    }
-                }).finishOnUiThread(Application::getDefaultModalityState, Runnable::run).withDocumentsCommitted(myProject).expireWith(hintDisposable).expireWhen(() -> !info.isValid(editor.getDocument()))
-                .coalesceBy(hint).submit(AppExecutorUtil.getAppExecutorService()));
+            myProject.getMessageBus().connect(hintDisposable).subscribe(
+                PsiModificationTrackerListener.class,
+                () -> ReadAction.nonBlocking(() -> {
+                        try {
+                            DocInfo newDocInfo = info.getInfo();
+                            return (Runnable) () -> {
+                                if (newDocInfo.text != null && !oldText.equals(newDocInfo.text)) {
+                                    updateText(newDocInfo.text, textConsumer, hint, editor);
+                                }
+                            };
+                        }
+                        catch (IndexNotReadyException e) {
+                            showDumbModeNotification(myProject);
+                            return createDisposalContinuation();
+                        }
+                    })
+                    .finishOnUiThread(Application::getDefaultModalityState, Runnable::run)
+                    .withDocumentsCommitted(myProject)
+                    .expireWith(hintDisposable)
+                    .expireWhen(() -> !info.isValid(editor.getDocument()))
+                    .coalesceBy(hint)
+                    .submit(AppExecutorUtil.getAppExecutorService())
+            );
         }
 
         @RequiredUIAccess
@@ -880,14 +899,14 @@ public final class CtrlMouseHandler {
     private HighlightersSet installHighlighterSet(Info info, EditorEx editor, boolean highlighterOnly) {
         editor.getContentComponent().addKeyListener(myEditorKeyListener);
         editor.getScrollingModel().addVisibleAreaListener(myVisibleAreaListener);
-        if (info.isNavigatable()) {
+        if (info.isNavigable()) {
             editor.setCustomCursor(CtrlMouseHandler.class, Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         }
 
         List<RangeHighlighter> highlighters = new ArrayList<>();
 
-        if (!highlighterOnly || info.isNavigatable()) {
-            TextAttributes attributes = info.isNavigatable()
+        if (!highlighterOnly || info.isNavigable()) {
+            TextAttributes attributes = info.isNavigable()
                 ? EditorColorsManager.getInstance().getGlobalScheme().getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)
                 : new TextAttributes(null, HintUtil.getInformationColor(), null, null, Font.PLAIN);
             for (TextRange range : info.getRanges()) {
@@ -937,7 +956,6 @@ public final class CtrlMouseHandler {
             myHighlighterView.getScrollingModel().removeVisibleAreaListener(myVisibleAreaListener);
         }
 
-        
         Info getStoredInfo() {
             return myStoredInfo;
         }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/codeInsight/navigation/GotoTargetHandler.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/codeInsight/navigation/GotoTargetHandler.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package consulo.ide.impl.idea.codeInsight.navigation;
 
 import consulo.annotation.access.RequiredReadAction;
@@ -39,7 +38,7 @@ import consulo.language.psi.util.EditSourceUtil;
 import consulo.localize.LocalizeValue;
 import consulo.logging.Logger;
 import consulo.navigation.ItemPresentation;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.NavigationItem;
 import consulo.project.DumbService;
 import consulo.project.Project;
@@ -83,7 +82,7 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
         }
         catch (IndexNotReadyException e) {
             DumbService.getInstance(project)
-                .showDumbModeNotification(LocalizeValue.localizeTODO("Navigation is not available here during index update"));
+                    .showDumbModeNotification(LocalizeValue.localizeTODO("Navigation is not available here during index update"));
         }
     }
 
@@ -92,12 +91,7 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
     protected abstract @Nullable GotoData getSourceAndTargetElements(Editor editor, PsiFile file);
 
     @RequiredUIAccess
-    private void show(
-        Project project,
-        Editor editor,
-        PsiFile file,
-        GotoData gotoData
-    ) {
+    private void show(Project project, Editor editor, PsiFile file, GotoData gotoData) {
         PsiElement[] targets = gotoData.targets;
         List<AdditionalAction> additionalActions = gotoData.additionalActions;
 
@@ -167,8 +161,8 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
                     additionalAction.execute();
                 }
                 else {
-                    Navigatable nav =
-                        element instanceof Navigatable navigatable ? navigatable : EditSourceUtil.getDescriptor((PsiElement)element);
+                    Navigable nav =
+                        element instanceof Navigable navigable ? navigable : EditSourceUtil.getDescriptor((PsiElement)element);
                     try {
                         if (nav != null && nav.canNavigate()) {
                             navigateToElement(nav);
@@ -229,7 +223,6 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
         }
     }
 
-    
     private PsiElementListCellRenderer getRenderer(
         Object value,
         Map<Object, PsiElementListCellRenderer> targetsWithRenderers,
@@ -242,7 +235,6 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
         return renderer != null ? renderer : myDefaultTargetElementRenderer;
     }
 
-    
     protected Comparator<PsiElement> createComparator(
         Map<Object, PsiElementListCellRenderer> targetsWithRenderers,
         GotoData gotoData
@@ -263,8 +255,9 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
         return GotoTargetRendererProvider.EP_NAME.computeSafeIfAny(Application.get(), it -> it.getRenderer(eachTarget, gotoData));
     }
 
+    @RequiredUIAccess
     protected boolean navigateToElement(PsiElement target) {
-        Navigatable descriptor = target instanceof Navigatable navigatable ? navigatable : EditSourceUtil.getDescriptor(target);
+        Navigable descriptor = target instanceof Navigable navigable ? navigable : EditSourceUtil.getDescriptor(target);
         if (descriptor != null && descriptor.canNavigate()) {
             navigateToElement(descriptor);
             return true;
@@ -272,7 +265,8 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
         return false;
     }
 
-    protected void navigateToElement(Navigatable descriptor) {
+    @RequiredUIAccess
+    protected void navigateToElement(Navigable descriptor) {
         descriptor.navigate(true);
     }
 
@@ -280,24 +274,20 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
         return true;
     }
 
-    
     @Deprecated // use getChooserTitle(PsiElement, String, int, boolean) instead
     protected String getChooserTitle(PsiElement sourceElement, String name, int length) {
         LOG.warn("Please override getChooserTitle(PsiElement, String, int, boolean) instead");
         return "";
     }
 
-    
     protected String getChooserTitle(PsiElement sourceElement, String name, int length, boolean finished) {
         return getChooserTitle(sourceElement, name, length);
     }
 
-    
     protected String getFindUsagesTitle(PsiElement sourceElement, String name, int length) {
         return getChooserTitle(sourceElement, name, length, true);
     }
 
-    
     protected abstract String getNotFoundMessage(Project project, Editor editor, PsiFile file);
 
     protected @Nullable String getAdText(PsiElement source, int length) {
@@ -305,7 +295,6 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
     }
 
     public interface AdditionalAction {
-        
         String getText();
 
         Image getIcon();
@@ -314,7 +303,6 @@ public abstract class GotoTargetHandler implements CodeInsightActionHandler {
     }
 
     public static class GotoData implements GotoTargetRendererProvider.Options {
-        
         public final PsiElement source;
         public PsiElement[] targets;
         public final List<AdditionalAction> additionalActions;

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/OccurenceNavigatorSupport.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/OccurenceNavigatorSupport.java
@@ -15,11 +15,11 @@
  */
 package consulo.ide.impl.idea.ide;
 
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.ex.OccurenceNavigator;
 import consulo.ui.ex.awt.tree.TreeUtil;
-
 import org.jspecify.annotations.Nullable;
+
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
@@ -27,113 +27,123 @@ import javax.swing.tree.TreePath;
 import java.util.Enumeration;
 
 public abstract class OccurenceNavigatorSupport implements OccurenceNavigator {
-  private final JTree myTree;
+    private final JTree myTree;
 
-  public OccurenceNavigatorSupport(JTree tree) {
-    myTree = tree;
-  }
-
-  protected abstract @Nullable Navigatable createDescriptorForNode(DefaultMutableTreeNode node);
-
-  /**
-   * @return true if this node is an actual occurrence, i.e. the "next/prev occurrence" actions should show this node (as opposed to groups or other nodes which should be skipped)
-   * Override in your occurrence support for more efficient impl
-   */
-  protected boolean isOccurrenceNode(DefaultMutableTreeNode node) {
-    return createDescriptorForNode(node) != null;
-  }
-
-  @Override
-  public OccurenceInfo goNextOccurence() {
-    DefaultMutableTreeNode node = findNode(myTree, true);
-    if (node == null) return null;
-    TreePath treePath = new TreePath(node.getPath());
-    TreeUtil.selectPath(myTree, treePath);
-    Navigatable editSourceDescriptor = createDescriptorForNode(node);
-    if (editSourceDescriptor == null) return null;
-    Counters counters = calculatePosition(node);
-    return new OccurenceInfo(editSourceDescriptor, counters.myFoundOccurenceNumber, counters.myOccurencesCount);
-  }
-
-  @Override
-  public OccurenceInfo goPreviousOccurence() {
-    DefaultMutableTreeNode node = findNode(myTree, false);
-    if (node == null) return null;
-    TreePath treePath = new TreePath(node.getPath());
-    TreeUtil.selectPath(myTree, treePath);
-    Navigatable editSourceDescriptor = createDescriptorForNode(node);
-    if (editSourceDescriptor == null) return null;
-    Counters counters = calculatePosition(node);
-    return new OccurenceInfo(editSourceDescriptor, counters.myFoundOccurenceNumber, counters.myOccurencesCount);
-  }
-
-  
-  private Counters calculatePosition(DefaultMutableTreeNode foundNode) {
-    Counters counters = new Counters();
-    @SuppressWarnings("unchecked") Enumeration<TreeNode> enumeration = ((DefaultMutableTreeNode)foundNode.getRoot()).preorderEnumeration();
-    while (enumeration.hasMoreElements()) {
-      TreeNode node = enumeration.nextElement();
-      if (node instanceof DefaultMutableTreeNode && isOccurrenceNode((DefaultMutableTreeNode)node)) {
-        counters.myOccurencesCount++;
-      }
-      if (node == foundNode) {
-        counters.myFoundOccurenceNumber = counters.myOccurencesCount;
-      }
+    public OccurenceNavigatorSupport(JTree tree) {
+        myTree = tree;
     }
-    return counters;
-  }
 
-  @Override
-  public boolean hasNextOccurence() {
-    DefaultMutableTreeNode node = findNode(myTree, true);
-    return node != null;
-  }
+    protected abstract @Nullable Navigable createDescriptorForNode(DefaultMutableTreeNode node);
 
-  @Override
-  public boolean hasPreviousOccurence() {
-    DefaultMutableTreeNode node = findNode(myTree, false);
-    return node != null;
-  }
-
-  private static class Counters {
     /**
-     * Equals to {@code -1} if this value is unsupported.
+     * @return true if this node is an actual occurrence, i.e. the "next/prev occurrence" actions should show this node (as opposed to groups or other nodes which should be skipped)
+     * Override in your occurrence support for more efficient impl
      */
-    int myFoundOccurenceNumber; // starts with 1
-    /**
-     * Equals to {@code -1} if this value is unsupported.
-     */
-    int myOccurencesCount;
-  }
-
-  private DefaultMutableTreeNode findNode(JTree tree, boolean forward) {
-    TreePath selectionPath = tree.getSelectionPath();
-    TreeNode selectedNode = null;
-    if (selectionPath != null) {
-      selectedNode = (TreeNode)selectionPath.getLastPathComponent();
+    protected boolean isOccurrenceNode(DefaultMutableTreeNode node) {
+        return createDescriptorForNode(node) != null;
     }
-    return findNextNodeAfter(tree, selectedNode, forward);
-  }
 
-  public DefaultMutableTreeNode findNextNodeAfter(JTree tree, TreeNode selectedNode, boolean forward) {
-    if (selectedNode == null) {
-      selectedNode = (TreeNode)tree.getModel().getRoot();
-    }
-    if (forward) {
-      for (DefaultMutableTreeNode node = ((DefaultMutableTreeNode)selectedNode).getNextNode(); node != null; node = node.getNextNode()) {
-        if (createDescriptorForNode(node) != null) {
-          return node;
+    @Override
+    public OccurenceInfo goNextOccurence() {
+        DefaultMutableTreeNode node = findNode(myTree, true);
+        if (node == null) {
+            return null;
         }
-      }
-    }
-    else {
-      for (DefaultMutableTreeNode node = ((DefaultMutableTreeNode)selectedNode).getPreviousNode(); node != null; node = node.getPreviousNode()) {
-        if (createDescriptorForNode(node) != null) {
-          return node;
+        TreePath treePath = new TreePath(node.getPath());
+        TreeUtil.selectPath(myTree, treePath);
+        Navigable editSourceDescriptor = createDescriptorForNode(node);
+        if (editSourceDescriptor == null) {
+            return null;
         }
-      }
+        Counters counters = calculatePosition(node);
+        return new OccurenceInfo(editSourceDescriptor, counters.myFoundOccurenceNumber, counters.myOccurencesCount);
     }
 
-    return null;
-  }
+    @Override
+    public OccurenceInfo goPreviousOccurence() {
+        DefaultMutableTreeNode node = findNode(myTree, false);
+        if (node == null) {
+            return null;
+        }
+        TreePath treePath = new TreePath(node.getPath());
+        TreeUtil.selectPath(myTree, treePath);
+        Navigable editSourceDescriptor = createDescriptorForNode(node);
+        if (editSourceDescriptor == null) {
+            return null;
+        }
+        Counters counters = calculatePosition(node);
+        return new OccurenceInfo(editSourceDescriptor, counters.myFoundOccurenceNumber, counters.myOccurencesCount);
+    }
+
+    private Counters calculatePosition(DefaultMutableTreeNode foundNode) {
+        Counters counters = new Counters();
+        @SuppressWarnings("unchecked") Enumeration<TreeNode> enumeration =
+            ((DefaultMutableTreeNode) foundNode.getRoot()).preorderEnumeration();
+        while (enumeration.hasMoreElements()) {
+            TreeNode node = enumeration.nextElement();
+            if (node instanceof DefaultMutableTreeNode && isOccurrenceNode((DefaultMutableTreeNode) node)) {
+                counters.myOccurencesCount++;
+            }
+            if (node == foundNode) {
+                counters.myFoundOccurenceNumber = counters.myOccurencesCount;
+            }
+        }
+        return counters;
+    }
+
+    @Override
+    public boolean hasNextOccurence() {
+        DefaultMutableTreeNode node = findNode(myTree, true);
+        return node != null;
+    }
+
+    @Override
+    public boolean hasPreviousOccurence() {
+        DefaultMutableTreeNode node = findNode(myTree, false);
+        return node != null;
+    }
+
+    private static class Counters {
+        /**
+         * Equals to {@code -1} if this value is unsupported.
+         */
+        int myFoundOccurenceNumber; // starts with 1
+        /**
+         * Equals to {@code -1} if this value is unsupported.
+         */
+        int myOccurencesCount;
+    }
+
+    private DefaultMutableTreeNode findNode(JTree tree, boolean forward) {
+        TreePath selectionPath = tree.getSelectionPath();
+        TreeNode selectedNode = null;
+        if (selectionPath != null) {
+            selectedNode = (TreeNode) selectionPath.getLastPathComponent();
+        }
+        return findNextNodeAfter(tree, selectedNode, forward);
+    }
+
+    public DefaultMutableTreeNode findNextNodeAfter(JTree tree, TreeNode selectedNode, boolean forward) {
+        if (selectedNode == null) {
+            selectedNode = (TreeNode) tree.getModel().getRoot();
+        }
+        if (forward) {
+            for (DefaultMutableTreeNode node = ((DefaultMutableTreeNode) selectedNode).getNextNode(); node != null;
+                 node = node.getNextNode()) {
+                if (createDescriptorForNode(node) != null) {
+                    return node;
+                }
+            }
+        }
+        else {
+            for (DefaultMutableTreeNode node = ((DefaultMutableTreeNode) selectedNode).getPreviousNode(); node != null;
+                 node = node.getPreviousNode()) {
+                if (createDescriptorForNode(node) != null) {
+                    return node;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/actions/OpenInRightSplitAction.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/actions/OpenInRightSplitAction.java
@@ -21,7 +21,7 @@ import consulo.fileEditor.*;
 import consulo.fileEditor.internal.FileEditorManagerEx;
 import consulo.language.psi.PsiElement;
 import consulo.language.psi.PsiFile;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.platform.base.localize.ActionLocalize;
 import consulo.project.Project;
@@ -31,7 +31,6 @@ import consulo.ui.ex.action.AnActionEvent;
 import consulo.ui.ex.action.DumbAwareAction;
 import consulo.util.lang.ObjectUtil;
 import consulo.virtualFileSystem.VirtualFile;
-
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -52,7 +51,7 @@ public class OpenInRightSplitAction extends DumbAwareAction {
     public void actionPerformed(AnActionEvent e) {
         Project project = e.getRequiredData(Project.KEY);
         VirtualFile file = e.getRequiredData(VirtualFile.KEY);
-        Navigatable element = ObjectUtil.tryCast(e.getData(PsiElement.KEY), Navigatable.class);
+        Navigable element = ObjectUtil.tryCast(e.getData(PsiElement.KEY), Navigable.class);
 
         FileEditorWindow editorWindow = openInRightSplit(project, file, element, true);
         if (element == null && editorWindow != null) {
@@ -85,7 +84,7 @@ public class OpenInRightSplitAction extends DumbAwareAction {
     public static @Nullable FileEditorWindow openInRightSplit(
         Project project,
         VirtualFile file,
-        @Nullable Navigatable element,
+        @Nullable Navigable element,
         boolean requestFocus
     ) {
         FileEditorManagerEx fileEditorManager = FileEditorManagerEx.getInstanceEx(project);

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/actions/searcheverywhere/AbstractGotoSEContributor.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/actions/searcheverywhere/AbstractGotoSEContributor.java
@@ -26,7 +26,7 @@ import consulo.language.psi.util.EditSourceUtil;
 import consulo.localize.LocalizeValue;
 import consulo.logging.Logger;
 import consulo.navigation.ItemPresentation;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.navigation.NavigationItem;
 import consulo.project.DumbService;
 import consulo.project.Project;
@@ -332,9 +332,9 @@ public abstract class AbstractGotoSEContributor implements WeightedSearchEverywh
             }
 
             PsiElement psiElement = preparePsi(element, modifiers, searchText);
-            Navigatable extNavigatable = createExtendedNavigatable(psiElement, searchText, modifiers);
-            if (extNavigatable != null && extNavigatable.canNavigate()) {
-                extNavigatable.navigate(true);
+            Navigable extNavigable = createExtendedNavigable(psiElement, searchText, modifiers);
+            if (extNavigable != null && extNavigable.canNavigate()) {
+                extNavigable.navigate(true);
                 return true;
             }
 
@@ -387,7 +387,8 @@ public abstract class AbstractGotoSEContributor implements WeightedSearchEverywh
         return 50;
     }
 
-    protected @Nullable Navigatable createExtendedNavigatable(PsiElement psi, String searchText, int modifiers) {
+    @RequiredReadAction
+    protected @Nullable Navigable createExtendedNavigable(PsiElement psi, String searchText, int modifiers) {
         VirtualFile file = PsiUtilCore.getVirtualFile(psi);
         Couple<Integer> position = getLineAndColumn(searchText);
         boolean positionSpecified = position.first >= 0 || position.second >= 0;

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/actions/searcheverywhere/ClassSearchEverywhereContributor.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/actions/searcheverywhere/ClassSearchEverywhereContributor.java
@@ -16,8 +16,10 @@ import consulo.language.psi.PsiElement;
 import consulo.language.psi.PsiUtilCore;
 import consulo.language.util.LanguageUtil;
 import consulo.localize.LocalizeValue;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.AnAction;
 import consulo.util.lang.StringUtil;
 import consulo.virtualFileSystem.VirtualFile;
@@ -112,8 +114,8 @@ public class ClassSearchEverywhereContributor extends AbstractGotoSEContributor 
 
     @Override
     @RequiredReadAction
-    protected @Nullable Navigatable createExtendedNavigatable(PsiElement psi, String searchText, int modifiers) {
-        Navigatable res = super.createExtendedNavigatable(psi, searchText, modifiers);
+    protected @Nullable Navigable createExtendedNavigable(PsiElement psi, String searchText, int modifiers) {
+        Navigable res = super.createExtendedNavigable(psi, searchText, modifiers);
         if (res != null) {
             return res;
         }
@@ -121,22 +123,24 @@ public class ClassSearchEverywhereContributor extends AbstractGotoSEContributor 
         VirtualFile file = PsiUtilCore.getVirtualFile(psi);
         String memberName = getMemberName(searchText);
         if (file != null && memberName != null) {
-            Navigatable delegate = GotoClassAction.findMember(memberName, searchText, psi, file);
+            Navigable delegate = GotoClassAction.findMember(memberName, searchText, psi, file);
             if (delegate != null) {
                 return new Navigatable() {
                     @Override
+                    @RequiredUIAccess
                     public void navigate(boolean requestFocus) {
                         PopupNavigationUtil.activateFileWithPsiElement(psi, openInCurrentWindow(modifiers));
                         delegate.navigate(true);
-
                     }
 
                     @Override
+                    @RequiredReadAction
                     public boolean canNavigate() {
                         return delegate.canNavigate();
                     }
 
                     @Override
+                    @RequiredReadAction
                     public boolean canNavigateToSource() {
                         return delegate.canNavigateToSource();
                     }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/ErrorViewStructure.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/ErrorViewStructure.java
@@ -15,6 +15,7 @@
  */
 package consulo.ide.impl.idea.ide.errorTreeView;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.application.Application;
 import consulo.fileEditor.impl.internal.OpenFileDescriptorImpl;
 import consulo.ide.impl.idea.ide.errorTreeView.impl.ErrorTreeViewConfiguration;
@@ -22,7 +23,7 @@ import consulo.ide.impl.idea.ui.CustomizeColoredTreeCellRenderer;
 import consulo.language.editor.DaemonCodeAnalyzer;
 import consulo.language.psi.PsiFile;
 import consulo.language.psi.PsiManager;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.ui.ex.awt.SimpleColoredComponent;
 import consulo.ui.ex.errorTreeView.ErrorTreeElementKind;
@@ -48,7 +49,7 @@ public class ErrorViewStructure extends AbstractTreeStructure {
 
     private final List<String> myGroupNames = new ArrayList<>();
     private final Map<String, GroupingElement> myGroupNameToElementMap = new HashMap<>();
-    private final Map<String, List<NavigatableMessageElement>> myGroupNameToMessagesMap = new HashMap<>();
+    private final Map<String, List<NavigableMessageElement>> myGroupNameToMessagesMap = new HashMap<>();
     private final Map<ErrorTreeElementKind, List<ErrorTreeElement>> mySimpleMessages = new EnumMap<>(ErrorTreeElementKind.class);
     private final Object myLock = new Object();
 
@@ -97,20 +98,20 @@ public class ErrorViewStructure extends AbstractTreeStructure {
 
         if (element instanceof GroupingElement) {
             synchronized (myLock) {
-                List<NavigatableMessageElement> children = myGroupNameToMessagesMap.get(((GroupingElement) element).getName());
+                List<NavigableMessageElement> children = myGroupNameToMessagesMap.get(((GroupingElement) element).getName());
                 if (children != null && !children.isEmpty()) {
                     if (myConfiguration != null) {
                         List<ErrorTreeElement> filtered = new ArrayList<>(children.size());
-                        for (NavigatableMessageElement navigatableMessageElement : children) {
-                            ErrorTreeElementKind kind = navigatableMessageElement.getKind();
+                        for (NavigableMessageElement navigableMessageElement : children) {
+                            ErrorTreeElementKind kind = navigableMessageElement.getKind();
                             if (!canShowKind(kind)) {
                                 continue;
                             }
-                            filtered.add(navigatableMessageElement);
+                            filtered.add(navigableMessageElement);
                         }
                         return ArrayUtil.toObjectArray(filtered, ErrorTreeElement.class);
                     }
-                    return ArrayUtil.toObjectArray(children, NavigatableMessageElement.class);
+                    return ArrayUtil.toObjectArray((List) children, NavigatableMessageElement.class);
                 }
             }
         }
@@ -123,9 +124,9 @@ public class ErrorViewStructure extends AbstractTreeStructure {
             return getChildCount(groupingElement) > 0;
         }
         synchronized (myLock) {
-            List<NavigatableMessageElement> children = myGroupNameToMessagesMap.get(groupingElement.getName());
+            List<NavigableMessageElement> children = myGroupNameToMessagesMap.get(groupingElement.getName());
             if (children != null) {
-                for (NavigatableMessageElement child : children) {
+                for (NavigableMessageElement child : children) {
                     ErrorTreeElementKind kind = child.getKind();
                     if (canShowKind(kind)) {
                         return true;
@@ -141,8 +142,8 @@ public class ErrorViewStructure extends AbstractTreeStructure {
         if (element instanceof GroupingElement || element instanceof SimpleMessageElement) {
             return myRoot;
         }
-        if (element instanceof NavigatableMessageElement) {
-            GroupingElement result = ((NavigatableMessageElement) element).getParent();
+        if (element instanceof NavigableMessageElement navigableMessageElement) {
+            GroupingElement result = navigableMessageElement.getParent();
             return result == null ? myRoot : result;
         }
         return null;
@@ -177,20 +178,20 @@ public class ErrorViewStructure extends AbstractTreeStructure {
                 line = column = -1;
             }
 
-            int guiline = line < 0 ? -1 : line + 1;
-            int guicolumn = column < 0 ? -1 : column + 1;
+            int guiLine = line < 0 ? -1 : line + 1;
+            int guiColumn = column < 0 ? -1 : column + 1;
 
             VirtualFile group = underFileGroup != null ? underFileGroup : file;
             VirtualFile nav = file != null ? file : underFileGroup;
 
-            addNavigatableMessage(
+            addNavigableMessage(
                 group.getPresentableUrl(),
                 new OpenFileDescriptorImpl(myProject, nav, line, column),
                 kind,
                 text,
                 data,
-                NewErrorTreeViewPanelImpl.createExportPrefix(guiline),
-                NewErrorTreeViewPanelImpl.createRendererPrefix(guiline, guicolumn),
+                NewErrorTreeViewPanelImpl.createExportPrefix(guiLine),
+                NewErrorTreeViewPanelImpl.createRendererPrefix(guiLine, guiColumn),
                 group
             );
         }
@@ -201,12 +202,12 @@ public class ErrorViewStructure extends AbstractTreeStructure {
 
     public List<Object> getGroupChildrenData(String groupName) {
         synchronized (myLock) {
-            List<NavigatableMessageElement> children = myGroupNameToMessagesMap.get(groupName);
+            List<NavigableMessageElement> children = myGroupNameToMessagesMap.get(groupName);
             if (children == null || children.isEmpty()) {
                 return Collections.emptyList();
             }
             List<Object> result = new ArrayList<>();
-            for (NavigatableMessageElement child : children) {
+            for (NavigableMessageElement child : children) {
                 Object data = child.getData();
                 if (data != null) {
                     result.add(data);
@@ -230,9 +231,9 @@ public class ErrorViewStructure extends AbstractTreeStructure {
     }
 
     private void addGroupPlusElements(String text, GroupingElement group, List<SimpleErrorData> children) {
-        List<NavigatableMessageElement> elements = new ArrayList<>();
+        List<NavigableMessageElement> elements = new ArrayList<>();
         for (SimpleErrorData child : children) {
-            elements.add(new MyNavigatableWithDataElement(
+            elements.add(new MyNavigableWithDataElement(
                 myProject,
                 child.getKind(),
                 group,
@@ -254,9 +255,9 @@ public class ErrorViewStructure extends AbstractTreeStructure {
         addSimpleMessage(kind, text, data);
     }
 
-    public void addNavigatableMessage(
+    public void addNavigableMessage(
         @Nullable String groupName,
-        Navigatable navigatable,
+        Navigable navigable,
         ErrorTreeElementKind kind,
         String[] message,
         Object data,
@@ -265,11 +266,11 @@ public class ErrorViewStructure extends AbstractTreeStructure {
         VirtualFile file
     ) {
         if (groupName == null) {
-            addSimpleMessageElement(new NavigatableMessageElement(kind, null, message, navigatable, exportText, rendererTextPrefix));
+            addSimpleMessageElement(new NavigatableMessageElement(kind, null, message, navigable, exportText, rendererTextPrefix));
         }
         else {
             synchronized (myLock) {
-                List<NavigatableMessageElement> elements = myGroupNameToMessagesMap.get(groupName);
+                List<NavigableMessageElement> elements = myGroupNameToMessagesMap.get(groupName);
                 if (elements == null) {
                     elements = new ArrayList<>();
                     myGroupNameToMessagesMap.put(groupName, elements);
@@ -278,7 +279,7 @@ public class ErrorViewStructure extends AbstractTreeStructure {
                     kind,
                     getGroupingElement(groupName, data, file),
                     message,
-                    navigatable,
+                    navigable,
                     exportText,
                     rendererTextPrefix
                 ));
@@ -286,19 +287,42 @@ public class ErrorViewStructure extends AbstractTreeStructure {
         }
     }
 
-    public void addNavigatableMessage(String groupName, NavigatableMessageElement navigatableMessageElement) {
+    @Deprecated
+    @DeprecationInfo("Use #addNavigableMessage(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public void addNavigatableMessage(
+        @Nullable String groupName,
+        Navigable navigable,
+        ErrorTreeElementKind kind,
+        String[] message,
+        Object data,
+        String exportText,
+        String rendererTextPrefix,
+        VirtualFile file
+    ) {
+        addNavigableMessage(groupName, navigable, kind, message, data, exportText, rendererTextPrefix, file);
+    }
+
+    public void addNavigableMessage(String groupName, NavigableMessageElement navigableMessageElement) {
         synchronized (myLock) {
-            List<NavigatableMessageElement> elements = myGroupNameToMessagesMap.get(groupName);
+            List<NavigableMessageElement> elements = myGroupNameToMessagesMap.get(groupName);
             if (elements == null) {
                 elements = new ArrayList<>();
                 myGroupNameToMessagesMap.put(groupName, elements);
             }
             if (!myGroupNameToElementMap.containsKey(groupName)) {
                 myGroupNames.add(groupName);
-                myGroupNameToElementMap.put(groupName, navigatableMessageElement.getParent());
+                myGroupNameToElementMap.put(groupName, navigableMessageElement.getParent());
             }
-            elements.add(navigatableMessageElement);
+            elements.add(navigableMessageElement);
         }
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #addNavigableMessage(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public void addNavigatableMessage(String groupName, NavigableMessageElement navigableMessageElement) {
+        addNavigableMessage(groupName, navigableMessageElement);
     }
 
     private void addSimpleMessage(ErrorTreeElementKind kind, String[] text, Object data) {
@@ -337,7 +361,7 @@ public class ErrorViewStructure extends AbstractTreeStructure {
 
     public int getChildCount(GroupingElement groupingElement) {
         synchronized (myLock) {
-            List<NavigatableMessageElement> children = myGroupNameToMessagesMap.get(groupingElement.getName());
+            List<NavigableMessageElement> children = myGroupNameToMessagesMap.get(groupingElement.getName());
             return children == null ? 0 : children.size();
         }
     }
@@ -361,11 +385,11 @@ public class ErrorViewStructure extends AbstractTreeStructure {
                 return simpleMessages.get(0);
             }
             for (String path : myGroupNames) {
-                List<NavigatableMessageElement> messages = myGroupNameToMessagesMap.get(path);
+                List<NavigableMessageElement> messages = myGroupNameToMessagesMap.get(path);
                 if (messages != null) {
-                    for (NavigatableMessageElement navigatableMessageElement : messages) {
-                        if (kind.equals(navigatableMessageElement.getKind())) {
-                            return navigatableMessageElement;
+                    for (NavigableMessageElement navigableMessageElement : messages) {
+                        if (kind.equals(navigableMessageElement.getKind())) {
+                            return navigableMessageElement;
                         }
                     }
                 }
@@ -429,12 +453,11 @@ public class ErrorViewStructure extends AbstractTreeStructure {
                 });
             }
         }
-        else if (element instanceof NavigatableMessageElement) {
-            NavigatableMessageElement navElement = (NavigatableMessageElement) element;
+        else if (element instanceof NavigableMessageElement navElement) {
             GroupingElement parent = navElement.getParent();
             if (parent != null) {
                 synchronized (myLock) {
-                    List<NavigatableMessageElement> groupMessages = myGroupNameToMessagesMap.get(parent.getName());
+                    List<NavigableMessageElement> groupMessages = myGroupNameToMessagesMap.get(parent.getName());
                     if (groupMessages != null) {
                         groupMessages.remove(navElement);
                     }
@@ -451,11 +474,11 @@ public class ErrorViewStructure extends AbstractTreeStructure {
         }
     }
 
-    private static class MyNavigatableWithDataElement extends NavigatableMessageElement {
+    private static class MyNavigableWithDataElement extends NavigatableMessageElement {
         private final VirtualFile myVf;
         private final CustomizeColoredTreeCellRenderer myCustomizeColoredTreeCellRenderer;
 
-        private MyNavigatableWithDataElement(
+        private MyNavigableWithDataElement(
             Project project,
             ErrorTreeElementKind kind,
             GroupingElement parent,

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/NavigableMessageElement.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/NavigableMessageElement.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package consulo.ide.impl.idea.ide.errorTreeView;
+
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
+import consulo.navigation.Navigatable;
+import consulo.ui.ex.errorTreeView.ErrorTreeElementKind;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @author Eugene Zhuravlev
+ * @since 2004-11-12
+ */
+public class NavigableMessageElement extends ErrorTreeElement {
+    private final GroupingElement myParent;
+    private final String[] myMessage;
+    private final Navigable myNavigable;
+    private final String myExportText;
+    private final String myRendererTextPrefix;
+
+    public NavigableMessageElement(
+        ErrorTreeElementKind kind,
+        @Nullable GroupingElement parent,
+        String[] message,
+        Navigable navigable,
+        String exportText,
+        String rendererTextPrefix
+    ) {
+        super(kind);
+        myParent = parent;
+        myMessage = message;
+        myNavigable = navigable;
+        myExportText = exportText;
+        myRendererTextPrefix = rendererTextPrefix;
+    }
+
+    public Navigable getNavigable() {
+        return myNavigable;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public Navigatable getNavigatable() {
+        return (Navigatable) myNavigable;
+    }
+
+    @Override
+    public String[] getText() {
+        return myMessage;
+    }
+
+    @Override
+    public Object getData() {
+        return myParent.getData();
+    }
+
+    public @Nullable GroupingElement getParent() {
+        return myParent;
+    }
+
+    @Override
+    public String getExportTextPrefix() {
+        return getKind().getPresentableText() + myExportText;
+    }
+
+    public String getRendererTextPrefix() {
+        return myRendererTextPrefix;
+    }
+}

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/NavigatableMessageElement.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/NavigatableMessageElement.java
@@ -15,57 +15,27 @@
  */
 package consulo.ide.impl.idea.ide.errorTreeView;
 
-import consulo.navigation.Navigatable;
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.ui.ex.errorTreeView.ErrorTreeElementKind;
-
 import org.jspecify.annotations.Nullable;
 
 /**
  * @author Eugene Zhuravlev
  * @since 2004-11-12
  */
-public class NavigatableMessageElement extends ErrorTreeElement {
-  private final GroupingElement myParent;
-  private final String[] myMessage;
-  private final Navigatable myNavigatable;
-  private final String myExportText;
-  private final String myRendererTextPrefix;
-
-  public NavigatableMessageElement(ErrorTreeElementKind kind,
-                                   @Nullable GroupingElement parent,
-                                   String[] message,
-                                   Navigatable navigatable,
-                                   String exportText,
-                                   String rendererTextPrefix) {
-    super(kind);
-    myParent = parent;
-    myMessage = message;
-    myNavigatable = navigatable;
-    myExportText = exportText;
-    myRendererTextPrefix = rendererTextPrefix;
-  }
-
-  public Navigatable getNavigatable() {
-    return myNavigatable;
-  }
-
-  public String[] getText() {
-    return myMessage;
-  }
-
-  public Object getData() {
-    return myParent.getData();
-  }
-
-  public @Nullable GroupingElement getParent() {
-    return myParent;
-  }
-
-  public String getExportTextPrefix() {
-    return getKind().getPresentableText() + myExportText;
-  }
-
-  public String getRendererTextPrefix() {
-    return myRendererTextPrefix;
-  }
+@Deprecated
+@DeprecationInfo("Use NavigableMessageElement, typo-corrected name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+public class NavigatableMessageElement extends NavigableMessageElement {
+    public NavigatableMessageElement(
+        ErrorTreeElementKind kind,
+        @Nullable GroupingElement parent,
+        String[] message,
+        Navigable navigable,
+        String exportText,
+        String rendererTextPrefix
+    ) {
+        super(kind, parent, message, navigable, exportText, rendererTextPrefix);
+    }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/NewErrorTreeViewPanelImpl.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/errorTreeView/NewErrorTreeViewPanelImpl.java
@@ -15,6 +15,7 @@
  */
 package consulo.ide.impl.idea.ide.errorTreeView;
 
+import consulo.annotation.access.RequiredReadAction;
 import consulo.application.AllIcons;
 import consulo.application.HelpManager;
 import consulo.application.impl.internal.IdeaModalityState;
@@ -24,16 +25,17 @@ import consulo.disposer.Disposer;
 import consulo.fileEditor.impl.internal.OpenFileDescriptorImpl;
 import consulo.ide.impl.idea.ide.OccurenceNavigatorSupport;
 import consulo.ide.impl.idea.ide.actions.ExportToTextFileToolbarAction;
-import consulo.project.ui.action.NextOccurenceToolbarAction;
-import consulo.project.ui.action.PreviousOccurenceToolbarAction;
 import consulo.ide.impl.idea.ide.errorTreeView.impl.ErrorTreeViewConfiguration;
 import consulo.ide.impl.idea.ide.errorTreeView.impl.ErrorViewTextExporter;
 import consulo.ide.localize.IdeLocalize;
 import consulo.language.editor.PlatformDataKeys;
 import consulo.localize.LocalizeValue;
 import consulo.logging.Logger;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
+import consulo.project.ui.action.NextOccurenceToolbarAction;
+import consulo.project.ui.action.PreviousOccurenceToolbarAction;
 import consulo.project.ui.view.MessageView;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.CopyProvider;
@@ -213,9 +215,9 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
         if (KEY == dataId) {
             return this;
         }
-        if (Navigatable.KEY == dataId) {
-            NavigatableMessageElement selectedMessageElement = getSelectedMessageElement();
-            return selectedMessageElement != null ? selectedMessageElement.getNavigatable() : null;
+        if (Navigable.KEY == dataId) {
+            NavigableMessageElement selectedMessageElement = getSelectedMessageElement();
+            return selectedMessageElement != null ? selectedMessageElement.getNavigable() : null;
         }
         else if (HelpManager.HELP_ID == dataId) {
             return myHelpId;
@@ -227,7 +229,7 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
             return myExporterToTextFile;
         }
         else if (CURRENT_EXCEPTION_DATA_KEY == dataId) {
-            NavigatableMessageElement selectedMessageElement = getSelectedMessageElement();
+            NavigableMessageElement selectedMessageElement = getSelectedMessageElement();
             return selectedMessageElement != null ? selectedMessageElement.getData() : null;
         }
         return null;
@@ -307,7 +309,7 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
         int type,
         String[] text,
         @Nullable String groupName,
-        Navigatable navigatable,
+        Navigable navigable,
         @Nullable String exportTextPrefix,
         @Nullable String rendererTextPrefix,
         @Nullable Object data
@@ -316,13 +318,13 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
             return;
         }
         VirtualFile file = data instanceof VirtualFile ? (VirtualFile) data : null;
-        if (file == null && navigatable instanceof OpenFileDescriptorImpl openFileDescriptor) {
+        if (file == null && navigable instanceof OpenFileDescriptorImpl openFileDescriptor) {
             file = openFileDescriptor.getFile();
         }
         String exportPrefix = exportTextPrefix == null ? "" : exportTextPrefix;
         String renderPrefix = rendererTextPrefix == null ? "" : rendererTextPrefix;
         ErrorTreeElementKind kind = ErrorTreeElementKind.convertMessageFromCompilerErrorType(type);
-        myErrorViewStructure.addNavigatableMessage(groupName, navigatable, kind, text, data, exportPrefix, renderPrefix, file);
+        myErrorViewStructure.addNavigableMessage(groupName, navigable, kind, text, data, exportPrefix, renderPrefix, file);
         myBuilder.updateTree();
     }
 
@@ -346,9 +348,8 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
         return this;
     }
 
-    private @Nullable NavigatableMessageElement getSelectedMessageElement() {
-        ErrorTreeElement selectedElement = getSelectedErrorTreeElement();
-        return selectedElement instanceof NavigatableMessageElement ? (NavigatableMessageElement) selectedElement : null;
+    private @Nullable NavigableMessageElement getSelectedMessageElement() {
+        return getSelectedErrorTreeElement() instanceof NavigableMessageElement selectedElement ? selectedElement : null;
     }
 
     public @Nullable ErrorTreeElement getSelectedErrorTreeElement() {
@@ -369,14 +370,15 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
         return (ErrorTreeNodeDescriptor) userObject;
     }
 
+    @RequiredReadAction
     private void navigateToSource(boolean focusEditor) {
-        NavigatableMessageElement element = getSelectedMessageElement();
+        NavigableMessageElement element = getSelectedMessageElement();
         if (element == null) {
             return;
         }
-        Navigatable navigatable = element.getNavigatable();
-        if (navigatable.canNavigate()) {
-            navigatable.navigate(focusEditor);
+        Navigable navigable = element.getNavigable();
+        if (navigable.canNavigate()) {
+            navigable.navigate(focusEditor);
         }
     }
 
@@ -390,7 +392,7 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
             return;
         }
         ActionGroup.Builder group = ActionGroup.newImmutableBuilder();
-        if (getData(Navigatable.KEY) != null) {
+        if (getData(Navigable.KEY) != null) {
             group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_EDIT_SOURCE));
         }
         group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_COPY));
@@ -726,8 +728,8 @@ public class NewErrorTreeViewPanelImpl extends JPanel implements DataProvider, N
             }
             ErrorTreeNodeDescriptor descriptor = (ErrorTreeNodeDescriptor) userObject;
             ErrorTreeElement element = descriptor.getElement();
-            if (element instanceof NavigatableMessageElement) {
-                return ((NavigatableMessageElement) element).getNavigatable();
+            if (element instanceof NavigableMessageElement navigableMessageElement) {
+                return navigableMessageElement.getNavigatable();
             }
             return null;
         }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/projectView/impl/nodes/NamedLibraryElementNode.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/projectView/impl/nodes/NamedLibraryElementNode.java
@@ -26,7 +26,7 @@ import consulo.ide.setting.module.OrderEntryTypeEditor;
 import consulo.ide.ui.OrderEntryAppearanceService;
 import consulo.localize.LocalizeValue;
 import consulo.module.content.layer.orderEntry.*;
-import consulo.navigation.NavigatableWithText;
+import consulo.navigation.NavigableWithText;
 import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.project.Project;
 import consulo.project.ui.view.internal.node.NamedLibraryElement;
@@ -49,12 +49,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class NamedLibraryElementNode extends ProjectViewNode<NamedLibraryElement> implements NavigatableWithText {
+public class NamedLibraryElementNode extends ProjectViewNode<NamedLibraryElement> implements NavigableWithText {
     public NamedLibraryElementNode(Project project, NamedLibraryElement value, ViewSettings viewSettings) {
         super(project, value, viewSettings);
     }
 
-    
     @Override
     @RequiredReadAction
     public Collection<AbstractTreeNode> getChildren() {
@@ -152,11 +151,11 @@ public class NamedLibraryElementNode extends ProjectViewNode<NamedLibraryElement
     }
 
     @Override
+    @RequiredReadAction
     public boolean canNavigate() {
         return true;
     }
 
-    
     @Override
     public LocalizeValue getNavigateActionText(boolean focusEditor) {
         return ProjectUIViewLocalize.actionOpenLibrarySettingsText();

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/structureView/newStructureView/StructureViewComponent.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/structureView/newStructureView/StructureViewComponent.java
@@ -1,7 +1,7 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
-
 package consulo.ide.impl.idea.ide.structureView.newStructureView;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.annotation.access.RequiredReadAction;
 import consulo.application.ApplicationManager;
 import consulo.application.HelpManager;
@@ -42,7 +42,7 @@ import consulo.language.psi.event.PsiTreeChangeAdapter;
 import consulo.language.psi.event.PsiTreeChangeEvent;
 import consulo.language.psi.util.PsiTreeUtil;
 import consulo.logging.Logger;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.project.ui.internal.ProjectIdeFocusManager;
 import consulo.project.ui.view.tree.AbstractTreeNode;
@@ -68,8 +68,8 @@ import consulo.util.concurrent.Promises;
 import consulo.util.dataholder.Key;
 import consulo.util.lang.Comparing;
 import consulo.util.lang.ObjectUtil;
-import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
+import org.jspecify.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.TreeModelEvent;
@@ -88,942 +88,1000 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 public class StructureViewComponent extends SimpleToolWindowPanel implements TreeActionsOwner, DataProvider, StructureView.Scrollable {
-  private static final Logger LOG = Logger.getInstance(StructureViewComponent.class);
+    private static final Logger LOG = Logger.getInstance(StructureViewComponent.class);
 
-  private static final Key<TreeState> STRUCTURE_VIEW_STATE_KEY = Key.create("STRUCTURE_VIEW_STATE");
-  private static final Key<Boolean> STRUCTURE_VIEW_STATE_RESTORED_KEY = Key.create("STRUCTURE_VIEW_STATE_RESTORED_KEY");
-  private static final AtomicInteger ourSettingsModificationCount = new AtomicInteger();
+    private static final Key<TreeState> STRUCTURE_VIEW_STATE_KEY = Key.create("STRUCTURE_VIEW_STATE");
+    private static final Key<Boolean> STRUCTURE_VIEW_STATE_RESTORED_KEY = Key.create("STRUCTURE_VIEW_STATE_RESTORED_KEY");
+    private static final AtomicInteger ourSettingsModificationCount = new AtomicInteger();
 
-  private FileEditor myFileEditor;
-  private final TreeModelWrapper myTreeModelWrapper;
+    private FileEditor myFileEditor;
+    private final TreeModelWrapper myTreeModelWrapper;
 
-  private final Project myProject;
-  private final StructureViewModel myTreeModel;
+    private final Project myProject;
+    private final StructureViewModel myTreeModel;
 
-  private final Tree myTree;
-  private final SmartTreeStructure myTreeStructure;
+    private final Tree myTree;
+    private final SmartTreeStructure myTreeStructure;
 
-  private final StructureTreeModel<SmartTreeStructure> myStructureTreeModel;
-  private final AsyncTreeModel myAsyncTreeModel;
-  private final SingleAlarm myUpdateAlarm;
+    private final StructureTreeModel<SmartTreeStructure> myStructureTreeModel;
+    private final AsyncTreeModel myAsyncTreeModel;
+    private final SingleAlarm myUpdateAlarm;
 
-  private volatile AsyncPromise<TreePath> myCurrentFocusPromise;
+    private volatile AsyncPromise<TreePath> myCurrentFocusPromise;
 
-  private boolean myAutoscrollFeedback;
-  private boolean myDisposed;
+    private boolean myAutoscrollFeedback;
+    private boolean myDisposed;
 
-  private final Alarm myAutoscrollAlarm = new Alarm(this);
+    private final Alarm myAutoscrollAlarm = new Alarm(this);
 
-  private final CopyPasteDelegator myCopyPasteDelegator;
-  private final MyAutoScrollToSourceHandler myAutoScrollToSourceHandler;
-  private final AutoScrollFromSourceHandler myAutoScrollFromSourceHandler;
+    private final CopyPasteDelegator myCopyPasteDelegator;
+    private final MyAutoScrollToSourceHandler myAutoScrollToSourceHandler;
+    private final AutoScrollFromSourceHandler myAutoScrollFromSourceHandler;
 
-  public StructureViewComponent(@Nullable FileEditor editor,
-                                StructureViewModel structureViewModel,
-                                Project project,
-                                boolean showRootNode) {
-    super(true, true);
+    public StructureViewComponent(
+        @Nullable FileEditor editor,
+        StructureViewModel structureViewModel,
+        Project project,
+        boolean showRootNode
+    ) {
+        super(true, true);
 
-    myProject = project;
-    myFileEditor = editor;
-    myTreeModel = structureViewModel;
-    myTreeModelWrapper = new TreeModelWrapper(myTreeModel, this);
+        myProject = project;
+        myFileEditor = editor;
+        myTreeModel = structureViewModel;
+        myTreeModelWrapper = new TreeModelWrapper(myTreeModel, this);
 
-    myTreeStructure = new SmartTreeStructure(project, myTreeModelWrapper) {
-      @Override
-      public void rebuildTree() {
-        if (isDisposed()) return;
-        super.rebuildTree();
-      }
+        myTreeStructure = new SmartTreeStructure(project, myTreeModelWrapper) {
+            @Override
+            public void rebuildTree() {
+                if (isDisposed()) {
+                    return;
+                }
+                super.rebuildTree();
+            }
 
-      @Override
-      public boolean isToBuildChildrenInBackground(Object element) {
-        return Registry.is("ide.structureView.StructureViewTreeStructure.BuildChildrenInBackground") || getRootElement() == element;
-      }
+            @Override
+            public boolean isToBuildChildrenInBackground(Object element) {
+                return Registry.is("ide.structureView.StructureViewTreeStructure.BuildChildrenInBackground") || getRootElement() == element;
+            }
 
-     
-      @Override
-      protected TreeElementWrapper createTree() {
-        return new MyNodeWrapper(myProject, myModel.getRoot(), myModel);
-      }
 
-      @Override
-      public String toString() {
-        return "structure view tree structure(model=" + myTreeModel + ")";
-      }
-    };
+            @Override
+            protected TreeElementWrapper createTree() {
+                return new MyNodeWrapper(myProject, myModel.getRoot(), myModel);
+            }
 
-    myStructureTreeModel = new StructureTreeModel<>(myTreeStructure, this);
-    myAsyncTreeModel = new AsyncTreeModel(myStructureTreeModel, this);
-    myAsyncTreeModel.setRootImmediately(myStructureTreeModel.getRootImmediately());
-    myTree = new MyTree(myAsyncTreeModel);
+            @Override
+            public String toString() {
+                return "structure view tree structure(model=" + myTreeModel + ")";
+            }
+        };
 
-    Disposer.register(this, myTreeModelWrapper);
+        myStructureTreeModel = new StructureTreeModel<>(myTreeStructure, this);
+        myAsyncTreeModel = new AsyncTreeModel(myStructureTreeModel, this);
+        myAsyncTreeModel.setRootImmediately(myStructureTreeModel.getRootImmediately());
+        myTree = new MyTree(myAsyncTreeModel);
 
-    registerAutoExpandListener(myTree, myTreeModel);
+        Disposer.register(this, myTreeModelWrapper);
 
-    myUpdateAlarm = new SingleAlarm(this::rebuild, 200, this);
-    myTree.setRootVisible(showRootNode);
-    myTree.getEmptyText().setText("Structure is empty");
+        registerAutoExpandListener(myTree, myTreeModel);
 
-    ModelListener modelListener = () -> queueUpdate();
-    myTreeModelWrapper.addModelListener(modelListener);
+        myUpdateAlarm = new SingleAlarm(this::rebuild, 200, this);
+        myTree.setRootVisible(showRootNode);
+        myTree.getEmptyText().setText("Structure is empty");
 
-    Disposer.register(this, () -> {
-      storeState();
-      myTreeModelWrapper.removeModelListener(modelListener);
-    });
+        ModelListener modelListener = () -> queueUpdate();
+        myTreeModelWrapper.addModelListener(modelListener);
 
-    setContent(ScrollPaneFactory.createScrollPane(myTree));
+        Disposer.register(this, () -> {
+            storeState();
+            myTreeModelWrapper.removeModelListener(modelListener);
+        });
 
-    myAutoScrollToSourceHandler = new MyAutoScrollToSourceHandler();
-    myAutoScrollFromSourceHandler = new MyAutoScrollFromSourceHandler(myProject, this);
-    myCopyPasteDelegator = new CopyPasteDelegator(myProject, myTree);
+        setContent(ScrollPaneFactory.createScrollPane(myTree));
 
-    setToolbar(createToolbar());
-    setupTree();
-  }
+        myAutoScrollToSourceHandler = new MyAutoScrollToSourceHandler();
+        myAutoScrollFromSourceHandler = new MyAutoScrollFromSourceHandler(myProject, this);
+        myCopyPasteDelegator = new CopyPasteDelegator(myProject, myTree);
 
-  public static void registerAutoExpandListener(JTree tree, StructureViewModel structureViewModel) {
-    tree.getModel()
-        .addTreeModelListener(new MyExpandListener(tree,
-                                                   ObjectUtil.tryCast(structureViewModel, StructureViewModel.ExpandInfoProvider.class)));
-  }
-
-  protected boolean showScrollToFromSourceActions() {
-    return true;
-  }
-
-  @Override
-  public FileEditor getFileEditor() {
-    return myFileEditor;
-  }
-
-  private StructureViewFactoryImpl.State getSettings() {
-    return ((StructureViewFactoryImpl)StructureViewFactory.getInstance(myProject)).getState();
-  }
-
-  public void showToolbar() {
-    setToolbar(createToolbar());
-  }
-
- 
-  private JComponent createToolbar() {
-    ActionToolbar toolbar =
-      ActionManager.getInstance().createActionToolbar(ActionPlaces.STRUCTURE_VIEW_TOOLBAR, createActionGroup(), true);
-    toolbar.setTargetComponent(this);
-    return toolbar.getComponent();
-  }
-
-  private void setupTree() {
-    myTree.setCellRenderer(new NodeRenderer());
-    myTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
-    myTree.setShowsRootHandles(true);
-    registerPsiListener(myProject, this, this::queueUpdate);
-    myProject.getMessageBus().connect(this).subscribe(UISettingsListener.class, o -> rebuild());
-
-    if (showScrollToFromSourceActions()) {
-      myAutoScrollToSourceHandler.install(myTree);
-      myAutoScrollFromSourceHandler.install();
+        setToolbar(createToolbar());
+        setupTree();
     }
 
-    TreeUtil.installActions(getTree());
+    public static void registerAutoExpandListener(JTree tree, StructureViewModel structureViewModel) {
+        tree.getModel()
+            .addTreeModelListener(new MyExpandListener(
+                tree,
+                ObjectUtil.tryCast(structureViewModel, StructureViewModel.ExpandInfoProvider.class)
+            ));
+    }
 
-    new TreeSpeedSearch(getTree(), treePath -> {
-      Object userObject = TreeUtil.getLastUserObject(treePath);
-      return userObject != null ? FileStructurePopup.getSpeedSearchText(userObject) : null;
-    });
+    protected boolean showScrollToFromSourceActions() {
+        return true;
+    }
 
-    addTreeKeyListener();
-    addTreeMouseListeners();
-    restoreState();
-  }
+    @Override
+    public FileEditor getFileEditor() {
+        return myFileEditor;
+    }
 
-  public static void registerPsiListener(Project project, Disposable disposable, Runnable onChange) {
-    MyPsiTreeChangeListener psiListener = new MyPsiTreeChangeListener(PsiManager.getInstance(project).getModificationTracker(), onChange);
-    PsiManager.getInstance(project).addPsiTreeChangeListener(psiListener, disposable);
-  }
+    private StructureViewFactoryImpl.State getSettings() {
+        return ((StructureViewFactoryImpl) StructureViewFactory.getInstance(myProject)).getState();
+    }
 
- 
-  public Project getProject() {
-    return myProject;
-  }
+    public void showToolbar() {
+        setToolbar(createToolbar());
+    }
 
- 
-  public JTree getTree() {
-    return myTree;
-  }
 
-  public void queueUpdate() {
-    myUpdateAlarm.cancelAndRequest();
-  }
+    private JComponent createToolbar() {
+        ActionToolbar toolbar =
+            ActionManager.getInstance().createActionToolbar(ActionPlaces.STRUCTURE_VIEW_TOOLBAR, createActionGroup(), true);
+        toolbar.setTargetComponent(this);
+        return toolbar.getComponent();
+    }
 
-  public void rebuild() {
-    myStructureTreeModel.getInvoker().runOrInvokeLater(() -> {
-      UIUtil.putClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY, null);
-      myTreeStructure.rebuildTree();
-      myStructureTreeModel.invalidate();
-    });
-  }
+    private void setupTree() {
+        myTree.setCellRenderer(new NodeRenderer());
+        myTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
+        myTree.setShowsRootHandles(true);
+        registerPsiListener(myProject, this, this::queueUpdate);
+        myProject.getMessageBus().connect(this).subscribe(UISettingsListener.class, o -> rebuild());
 
- 
-  private static JBTreeTraverser<Object> traverser() {
-    return JBTreeTraverser.from(o -> o instanceof Group ? ((Group)o).getChildren() : null);
-  }
-
-  private JBIterable<Object> getSelectedValues() {
-    return getSelectedValues(getTree());
-  }
-
- 
-  public static JBIterable<Object> getSelectedValues(JTree tree) {
-    return traverser().withRoots(JBIterable.of(tree.getSelectionPaths())
-                                           .map(TreePath::getLastPathComponent)
-                                           .filterMap(StructureViewComponent::unwrapValue)).traverse();
-  }
-
-  private void addTreeMouseListeners() {
-    EditSourceOnDoubleClickHandler.install(getTree());
-    CustomizationUtil.installPopupHandler(getTree(), IdeActions.GROUP_STRUCTURE_VIEW_POPUP, ActionPlaces.STRUCTURE_VIEW_POPUP);
-  }
-
-  private void addTreeKeyListener() {
-    getTree().addKeyListener(new KeyAdapter() {
-      @Override
-      public void keyPressed(KeyEvent e) {
-        if (KeyEvent.VK_ENTER == e.getKeyCode()) {
-          DataContext dataContext = DataManager.getInstance().getDataContext(getTree());
-          OpenSourceUtil.openSourcesFrom(dataContext, false);
+        if (showScrollToFromSourceActions()) {
+            myAutoScrollToSourceHandler.install(myTree);
+            myAutoScrollFromSourceHandler.install();
         }
-        else if (KeyEvent.VK_ESCAPE == e.getKeyCode()) {
-          if (e.isConsumed()) return;
-          PsiCopyPasteManager copyPasteManager = PsiCopyPasteManager.getInstance();
-          boolean[] isCopied = new boolean[1];
-          if (copyPasteManager.getElements(isCopied) != null && !isCopied[0]) {
-            copyPasteManager.clear();
-            e.consume();
-          }
+
+        TreeUtil.installActions(getTree());
+
+        new TreeSpeedSearch(getTree(), treePath -> {
+            Object userObject = TreeUtil.getLastUserObject(treePath);
+            return userObject != null ? FileStructurePopup.getSpeedSearchText(userObject) : null;
+        });
+
+        addTreeKeyListener();
+        addTreeMouseListeners();
+        restoreState();
+    }
+
+    public static void registerPsiListener(Project project, Disposable disposable, Runnable onChange) {
+        MyPsiTreeChangeListener psiListener =
+            new MyPsiTreeChangeListener(PsiManager.getInstance(project).getModificationTracker(), onChange);
+        PsiManager.getInstance(project).addPsiTreeChangeListener(psiListener, disposable);
+    }
+
+
+    public Project getProject() {
+        return myProject;
+    }
+
+
+    public JTree getTree() {
+        return myTree;
+    }
+
+    public void queueUpdate() {
+        myUpdateAlarm.cancelAndRequest();
+    }
+
+    public void rebuild() {
+        myStructureTreeModel.getInvoker().runOrInvokeLater(() -> {
+            UIUtil.putClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY, null);
+            myTreeStructure.rebuildTree();
+            myStructureTreeModel.invalidate();
+        });
+    }
+
+
+    private static JBTreeTraverser<Object> traverser() {
+        return JBTreeTraverser.from(o -> o instanceof Group ? ((Group) o).getChildren() : null);
+    }
+
+    private JBIterable<Object> getSelectedValues() {
+        return getSelectedValues(getTree());
+    }
+
+
+    public static JBIterable<Object> getSelectedValues(JTree tree) {
+        return traverser().withRoots(JBIterable.of(tree.getSelectionPaths())
+            .map(TreePath::getLastPathComponent)
+            .filterMap(StructureViewComponent::unwrapValue)).traverse();
+    }
+
+    private void addTreeMouseListeners() {
+        EditSourceOnDoubleClickHandler.install(getTree());
+        CustomizationUtil.installPopupHandler(getTree(), IdeActions.GROUP_STRUCTURE_VIEW_POPUP, ActionPlaces.STRUCTURE_VIEW_POPUP);
+    }
+
+    private void addTreeKeyListener() {
+        getTree().addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (KeyEvent.VK_ENTER == e.getKeyCode()) {
+                    DataContext dataContext = DataManager.getInstance().getDataContext(getTree());
+                    OpenSourceUtil.openSourcesFrom(dataContext, false);
+                }
+                else if (KeyEvent.VK_ESCAPE == e.getKeyCode()) {
+                    if (e.isConsumed()) {
+                        return;
+                    }
+                    PsiCopyPasteManager copyPasteManager = PsiCopyPasteManager.getInstance();
+                    boolean[] isCopied = new boolean[1];
+                    if (copyPasteManager.getElements(isCopied) != null && !isCopied[0]) {
+                        copyPasteManager.clear();
+                        e.consume();
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public void storeState() {
+        if (isDisposed() || !myProject.isOpen()) {
+            return;
         }
-      }
-    });
-  }
-
-  @Override
-  public void storeState() {
-    if (isDisposed() || !myProject.isOpen()) return;
-    Object root = myTree.getModel().getRoot();
-    if (root == null) return;
-    TreeState state = TreeState.createOn(myTree, new TreePath(root));
-    if (myFileEditor != null) {
-      myFileEditor.putUserData(STRUCTURE_VIEW_STATE_KEY, state);
-    }
-    UIUtil.putClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY, null);
-  }
-
-  @Override
-  public void restoreState() {
-    TreeState state = myFileEditor == null ? null : myFileEditor.getUserData(STRUCTURE_VIEW_STATE_KEY);
-    if (state == null) {
-      if (!Boolean.TRUE.equals(UIUtil.getClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY))) {
-        TreeUtil.expand(getTree(), getMinimumExpandDepth(myTreeModel));
-      }
-    }
-    else {
-      UIUtil.putClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY, true);
-      state.applyTo(myTree);
-      if (myFileEditor != null) {
-        myFileEditor.putUserData(STRUCTURE_VIEW_STATE_KEY, null);
-      }
-    }
-  }
-
- 
-  protected ActionGroup createActionGroup() {
-    DefaultActionGroup result = new DefaultActionGroup();
-    Sorter[] sorters = myTreeModel.getSorters();
-    for (Sorter sorter : sorters) {
-      if (sorter.isVisible()) {
-        result.add(new TreeActionWrapper(sorter, this));
-      }
-    }
-    if (sorters.length > 0) {
-      result.addSeparator();
-    }
-
-    addGroupByActions(result);
-
-    Filter[] filters = myTreeModel.getFilters();
-    for (Filter filter : filters) {
-      result.add(new TreeActionWrapper(filter, this));
-    }
-    if (myTreeModel instanceof ProvidingTreeModel) {
-      Collection<NodeProvider> providers = ((ProvidingTreeModel)myTreeModel).getNodeProviders();
-      for (NodeProvider provider : providers) {
-        result.add(new TreeActionWrapper(provider, this));
-      }
-    }
-
-    if (showScrollToFromSourceActions()) {
-      result.addSeparator();
-
-      result.add(myAutoScrollToSourceHandler.createToggleAction());
-      result.add(myAutoScrollFromSourceHandler.createToggleAction());
-    }
-    return result;
-  }
-
-  protected void addGroupByActions(DefaultActionGroup result) {
-    Grouper[] groupers = myTreeModel.getGroupers();
-    for (Grouper grouper : groupers) {
-      result.add(new TreeActionWrapper(grouper, this));
-    }
-  }
-
-  public Promise<AbstractTreeNode> expandPathToElement(Object element) {
-    return expandSelectFocusInner(element, false, false).then(p -> TreeUtil.getLastUserObject(AbstractTreeNode.class, p));
-  }
-
- 
-  public Promise<TreePath> select(Object element, boolean requestFocus) {
-    return expandSelectFocusInner(element, true, requestFocus);
-  }
-
- 
-  private Promise<TreePath> expandSelectFocusInner(Object element, boolean select, boolean requestFocus) {
-    AsyncPromise<TreePath> result = myCurrentFocusPromise = new AsyncPromise<>();
-    int[] stage = {1, 0}; // 1 - first pass, 2 - optimization applied, 3 - retry w/o optimization
-    TreePath[] deepestPath = {null};
-    TreeVisitor visitor = path -> {
-      if (myCurrentFocusPromise != result) {
-        result.setError("rejected");
-        return TreeVisitor.Action.INTERRUPT;
-      }
-      Object last = path.getLastPathComponent();
-      Object userObject = unwrapNavigatable(last);
-      Object value = unwrapValue(last);
-      if (Comparing.equal(value,
-                          element) || userObject instanceof AbstractTreeNode && ((AbstractTreeNode)userObject).canRepresent(element)) {
-        return TreeVisitor.Action.INTERRUPT;
-      }
-      if (value instanceof PsiElement && element instanceof PsiElement) {
-        if (PsiTreeUtil.isAncestor((PsiElement)value, (PsiElement)element, true)) {
-          int count = path.getPathCount();
-          if (stage[1] == 0 || stage[1] < count) {
-            stage[1] = count;
-            deepestPath[0] = path;
-          }
+        Object root = myTree.getModel().getRoot();
+        if (root == null) {
+            return;
         }
-        else if (stage[0] != 3) {
-          stage[0] = 2;
-          return TreeVisitor.Action.SKIP_CHILDREN;
+        TreeState state = TreeState.createOn(myTree, new TreePath(root));
+        if (myFileEditor != null) {
+            myFileEditor.putUserData(STRUCTURE_VIEW_STATE_KEY, state);
         }
-      }
-      return TreeVisitor.Action.CONTINUE;
-    };
-    Function<TreePath, Promise<TreePath>> action = path -> {
-      if (select) {
-        TreeUtil.selectPath(myTree, path);
-      }
-      else {
-        myTree.expandPath(path);
-      }
-      if (requestFocus) {
-        ProjectIdeFocusManager.getInstance(myProject).requestFocus(myTree, false);
-      }
-      return Promises.resolvedPromise(path);
-    };
-    Function<TreePath, Promise<TreePath>> fallback = new Function<TreePath, Promise<TreePath>>() {
-      @Override
-      public Promise<TreePath> apply(TreePath path) {
-        if (myCurrentFocusPromise != result) {
-          result.setError("rejected");
-          return Promises.rejectedPromise();
-        }
-        else if (path == null && stage[0] == 2) {
-          // Some structure views merge unrelated psi elements into a structure node (MarkdownStructureViewModel).
-          // So turn off the isAncestor() optimization and retry once.
-          stage[0] = 3;
-          return myAsyncTreeModel.accept(visitor).thenAsync(this);
+        UIUtil.putClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY, null);
+    }
+
+    @Override
+    public void restoreState() {
+        TreeState state = myFileEditor == null ? null : myFileEditor.getUserData(STRUCTURE_VIEW_STATE_KEY);
+        if (state == null) {
+            if (!Boolean.TRUE.equals(UIUtil.getClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY))) {
+                TreeUtil.expand(getTree(), getMinimumExpandDepth(myTreeModel));
+            }
         }
         else {
-          TreePath adjusted = path == null ? deepestPath[0] : path;
-          return adjusted == null ? Promises.rejectedPromise() : action.apply(adjusted);
+            UIUtil.putClientProperty(myTree, STRUCTURE_VIEW_STATE_RESTORED_KEY, true);
+            state.applyTo(myTree);
+            if (myFileEditor != null) {
+                myFileEditor.putUserData(STRUCTURE_VIEW_STATE_KEY, null);
+            }
         }
-      }
-    };
-    myAsyncTreeModel.accept(visitor).thenAsync(fallback).processed(result);
-    return myCurrentFocusPromise;
-  }
-
-  private void scrollToSelectedElement() {
-    if (myAutoscrollFeedback) {
-      myAutoscrollFeedback = false;
-      return;
     }
 
-    if (!getSettings().AUTOSCROLL_FROM_SOURCE) {
-      return;
-    }
 
-    myAutoscrollAlarm.cancelAllRequests();
-    myAutoscrollAlarm.addRequest(() -> {
-      if (isDisposed()) return;
-      if (UIUtil.isFocusAncestor(this)) return;
-      scrollToSelectedElementInner();
-    }, 1000);
-  }
-
-  private void scrollToSelectedElementInner() {
-    PsiDocumentManager.getInstance(myProject).performWhenAllCommitted(() -> {
-      try {
-        Object currentEditorElement = myTreeModel.getCurrentEditorElement();
-        if (currentEditorElement != null) {
-          select(currentEditorElement, false);
+    protected ActionGroup createActionGroup() {
+        DefaultActionGroup result = new DefaultActionGroup();
+        Sorter[] sorters = myTreeModel.getSorters();
+        for (Sorter sorter : sorters) {
+            if (sorter.isVisible()) {
+                result.add(new TreeActionWrapper(sorter, this));
+            }
         }
-      }
-      catch (IndexNotReadyException ignore) {
-      }
-    });
-  }
+        if (sorters.length > 0) {
+            result.addSeparator();
+        }
 
-  @Override
-  public void dispose() {
-    LOG.assertTrue(EventQueue.isDispatchThread(), Thread.currentThread().getName());
-    myDisposed = true;
-    myFileEditor = null;
-  }
+        addGroupByActions(result);
 
-  public boolean isDisposed() {
-    return myDisposed;
-  }
+        Filter[] filters = myTreeModel.getFilters();
+        for (Filter filter : filters) {
+            result.add(new TreeActionWrapper(filter, this));
+        }
+        if (myTreeModel instanceof ProvidingTreeModel) {
+            Collection<NodeProvider> providers = ((ProvidingTreeModel) myTreeModel).getNodeProviders();
+            for (NodeProvider provider : providers) {
+                result.add(new TreeActionWrapper(provider, this));
+            }
+        }
 
-  @Override
-  public void centerSelectedRow() {
-    TreePath path = getTree().getSelectionPath();
-    if (path == null) return;
+        if (showScrollToFromSourceActions()) {
+            result.addSeparator();
 
-    myAutoScrollToSourceHandler.setShouldAutoScroll(false);
-    TreeUtil.showRowCentered(getTree(), getTree().getRowForPath(path), false);
-    myAutoScrollToSourceHandler.setShouldAutoScroll(true);
-  }
-
-  @Override
-  @RequiredUIAccess
-  public void setActionActive(String name, boolean state) {
-    UIAccess.assertIsUIThread();
-    storeState();
-    StructureViewFactoryEx.getInstanceEx(myProject).setActiveAction(name, state);
-    ourSettingsModificationCount.incrementAndGet();
-
-    if (ApplicationManager.getApplication().isUnitTestMode()) {
-      waitForRebuildAndExpand();
-    }
-    else {
-      rebuild();
-      TreeUtil.expand(getTree(), getMinimumExpandDepth(myTreeModel));
-    }
-  }
-
-  @SuppressWarnings("TestOnlyProblems")
-  private void waitForRebuildAndExpand() {
-    wait(rebuildAndUpdate());
-    UIUtil.dispatchAllInvocationEvents();
-    wait(TreeUtil.promiseExpand(getTree(), getMinimumExpandDepth(myTreeModel)));
-  }
-
-  private static void wait(Promise<?> originPromise) {
-    AtomicBoolean complete = new AtomicBoolean(false);
-    Promise<?> promise = originPromise.onProcessed(ignore -> complete.set(true));
-    while (!complete.get()) {
-      //noinspection TestOnlyProblems
-      UIUtil.dispatchAllInvocationEvents();
-      try {
-        promise.blockingGet(10, TimeUnit.MILLISECONDS);
-      }
-      catch (Exception ignore) {
-      }
-    }
-  }
-
-  @Override
-  public boolean isActionActive(String name) {
-    return !myProject.isDisposed() && StructureViewFactoryEx.getInstanceEx(myProject).isActionActive(name);
-  }
-
-  private final class MyAutoScrollToSourceHandler extends AutoScrollToSourceHandler {
-    private boolean myShouldAutoScroll = true;
-
-    void setShouldAutoScroll(boolean shouldAutoScroll) {
-      myShouldAutoScroll = shouldAutoScroll;
+            result.add(myAutoScrollToSourceHandler.createToggleAction());
+            result.add(myAutoScrollFromSourceHandler.createToggleAction());
+        }
+        return result;
     }
 
-    @Override
-    protected boolean isAutoScrollMode() {
-      return myShouldAutoScroll && !myProject.isDisposed() && getSettings().AUTOSCROLL_MODE;
+    protected void addGroupByActions(DefaultActionGroup result) {
+        Grouper[] groupers = myTreeModel.getGroupers();
+        for (Grouper grouper : groupers) {
+            result.add(new TreeActionWrapper(grouper, this));
+        }
     }
 
-    @Override
-    protected void setAutoScrollMode(boolean state) {
-      getSettings().AUTOSCROLL_MODE = state;
+    public Promise<AbstractTreeNode> expandPathToElement(Object element) {
+        return expandSelectFocusInner(element, false, false).then(p -> TreeUtil.getLastUserObject(AbstractTreeNode.class, p));
     }
 
-    @Override
-    protected void scrollToSource(Component tree) {
-      if (isDisposed()) return;
-      myAutoscrollFeedback = true;
 
-      Navigatable navigatable = DataManager.getInstance().getDataContext(getTree()).getData(Navigatable.KEY);
-      if (myFileEditor != null && navigatable != null && navigatable.canNavigateToSource()) {
-        navigatable.navigate(false);
-      }
-    }
-  }
-
-  private class MyAutoScrollFromSourceHandler extends AutoScrollFromSourceHandler {
-    private FileEditorPositionListener myFileEditorPositionListener;
-
-    private MyAutoScrollFromSourceHandler(Project project, Disposable parentDisposable) {
-      super(project, getTree(), parentDisposable);
+    public Promise<TreePath> select(Object element, boolean requestFocus) {
+        return expandSelectFocusInner(element, true, requestFocus);
     }
 
-    @Override
-    public void install() {
-      addEditorCaretListener();
+
+    private Promise<TreePath> expandSelectFocusInner(Object element, boolean select, boolean requestFocus) {
+        AsyncPromise<TreePath> result = myCurrentFocusPromise = new AsyncPromise<>();
+        int[] stage = {1, 0}; // 1 - first pass, 2 - optimization applied, 3 - retry w/o optimization
+        TreePath[] deepestPath = {null};
+        TreeVisitor visitor = path -> {
+            if (myCurrentFocusPromise != result) {
+                result.setError("rejected");
+                return TreeVisitor.Action.INTERRUPT;
+            }
+            Object last = path.getLastPathComponent();
+            Object userObject = unwrapNavigable(last);
+            Object value = unwrapValue(last);
+            if (Comparing.equal(
+                value,
+                element
+            ) || userObject instanceof AbstractTreeNode && ((AbstractTreeNode) userObject).canRepresent(element)) {
+                return TreeVisitor.Action.INTERRUPT;
+            }
+            if (value instanceof PsiElement && element instanceof PsiElement) {
+                if (PsiTreeUtil.isAncestor((PsiElement) value, (PsiElement) element, true)) {
+                    int count = path.getPathCount();
+                    if (stage[1] == 0 || stage[1] < count) {
+                        stage[1] = count;
+                        deepestPath[0] = path;
+                    }
+                }
+                else if (stage[0] != 3) {
+                    stage[0] = 2;
+                    return TreeVisitor.Action.SKIP_CHILDREN;
+                }
+            }
+            return TreeVisitor.Action.CONTINUE;
+        };
+        Function<TreePath, Promise<TreePath>> action = path -> {
+            if (select) {
+                TreeUtil.selectPath(myTree, path);
+            }
+            else {
+                myTree.expandPath(path);
+            }
+            if (requestFocus) {
+                ProjectIdeFocusManager.getInstance(myProject).requestFocus(myTree, false);
+            }
+            return Promises.resolvedPromise(path);
+        };
+        Function<TreePath, Promise<TreePath>> fallback = new Function<TreePath, Promise<TreePath>>() {
+            @Override
+            public Promise<TreePath> apply(TreePath path) {
+                if (myCurrentFocusPromise != result) {
+                    result.setError("rejected");
+                    return Promises.rejectedPromise();
+                }
+                else if (path == null && stage[0] == 2) {
+                    // Some structure views merge unrelated psi elements into a structure node (MarkdownStructureViewModel).
+                    // So turn off the isAncestor() optimization and retry once.
+                    stage[0] = 3;
+                    return myAsyncTreeModel.accept(visitor).thenAsync(this);
+                }
+                else {
+                    TreePath adjusted = path == null ? deepestPath[0] : path;
+                    return adjusted == null ? Promises.rejectedPromise() : action.apply(adjusted);
+                }
+            }
+        };
+        myAsyncTreeModel.accept(visitor).thenAsync(fallback).processed(result);
+        return myCurrentFocusPromise;
+    }
+
+    private void scrollToSelectedElement() {
+        if (myAutoscrollFeedback) {
+            myAutoscrollFeedback = false;
+            return;
+        }
+
+        if (!getSettings().AUTOSCROLL_FROM_SOURCE) {
+            return;
+        }
+
+        myAutoscrollAlarm.cancelAllRequests();
+        myAutoscrollAlarm.addRequest(() -> {
+            if (isDisposed()) {
+                return;
+            }
+            if (UIUtil.isFocusAncestor(this)) {
+                return;
+            }
+            scrollToSelectedElementInner();
+        }, 1000);
+    }
+
+    private void scrollToSelectedElementInner() {
+        PsiDocumentManager.getInstance(myProject).performWhenAllCommitted(() -> {
+            try {
+                Object currentEditorElement = myTreeModel.getCurrentEditorElement();
+                if (currentEditorElement != null) {
+                    select(currentEditorElement, false);
+                }
+            }
+            catch (IndexNotReadyException ignore) {
+            }
+        });
     }
 
     @Override
     public void dispose() {
-      super.dispose();
-      if (myFileEditorPositionListener != null) {
-        myTreeModel.removeEditorPositionListener(myFileEditorPositionListener);
-      }
+        LOG.assertTrue(EventQueue.isDispatchThread(), Thread.currentThread().getName());
+        myDisposed = true;
+        myFileEditor = null;
     }
 
-    private void addEditorCaretListener() {
-      myFileEditorPositionListener = () -> scrollToSelectedElement();
-      myTreeModel.addEditorPositionListener(myFileEditorPositionListener);
-
-      if (isAutoScrollEnabled()) {
-        //otherwise on any tab switching selection will be staying at the top file node until we made a first caret move
-        scrollToSelectedElement();
-      }
+    public boolean isDisposed() {
+        return myDisposed;
     }
 
     @Override
-    protected boolean isAutoScrollEnabled() {
-      return getSettings().AUTOSCROLL_FROM_SOURCE;
-    }
-
-    @Override
-    protected void setAutoScrollEnabled(boolean state) {
-      getSettings().AUTOSCROLL_FROM_SOURCE = state;
-      FileEditor[] selectedEditors = FileEditorManager.getInstance(myProject).getSelectedEditors();
-      if (selectedEditors.length > 0 && state) {
-        scrollToSelectedElementInner();
-      }
-    }
-  }
-
-  @Override
-  public Object getData(Key dataId) {
-    if (PsiElement.KEY == dataId) {
-      PsiElement element = getSelectedValues().filter(PsiElement.class).single();
-      return element != null && element.isValid() ? element : null;
-    }
-    if (PsiElement.KEY_OF_ARRAY == dataId) {
-      return PsiUtilCore.toPsiElementArray(getSelectedValues().filter(PsiElement.class).toList());
-    }
-    if (FileEditor.KEY == dataId) {
-      return myFileEditor;
-    }
-    if (CutProvider.KEY == dataId) {
-      return myCopyPasteDelegator.getCutProvider();
-    }
-    if (CopyProvider.KEY == dataId) {
-      return myCopyPasteDelegator.getCopyProvider();
-    }
-    if (PasteProvider.KEY == dataId) {
-      return myCopyPasteDelegator.getPasteProvider();
-    }
-    if (Navigatable.KEY == dataId) {
-      List<Object> list = JBIterable.of(getTree().getSelectionPaths())
-        .map(TreePath::getLastPathComponent)
-        .map(StructureViewComponent::unwrapNavigatable)
-        .toList();
-      Object[] selectedElements = list.isEmpty() ? null : ArrayUtil.toObjectArray(list);
-      if (selectedElements == null || selectedElements.length == 0) return null;
-      if (selectedElements[0] instanceof Navigatable) {
-        return selectedElements[0];
-      }
-    }
-    if (HelpManager.HELP_ID == dataId) {
-      return getHelpID();
-    }
-    if (Project.KEY == dataId) {
-      return myProject;
-    }
-    return super.getData(dataId);
-  }
-
-  @Override
- 
-  public StructureViewModel getTreeModel() {
-    return myTreeModel;
-  }
-
-  @Override
-  public boolean navigateToSelectedElement(boolean requestFocus) {
-    select(myTreeModel.getCurrentEditorElement(), requestFocus);
-    return true;
-  }
-
-  @TestOnly
-  public AsyncPromise<Void> rebuildAndUpdate() {
-    AsyncPromise<Void> result = new AsyncPromise<>();
-    rebuild();
-    TreeVisitor visitor = path -> {
-      AbstractTreeNode node = TreeUtil.getLastUserObject(AbstractTreeNode.class, path);
-      if (node != null) node.update();
-      return TreeVisitor.Action.CONTINUE;
-    };
-    myAsyncTreeModel.accept(visitor).onProcessed(ignore -> result.setResult(null));
-    return result;
-  }
-
-  public String getHelpID() {
-    return "StructureView";
-  }
-
-  @Override
-  public Dimension getCurrentSize() {
-    return getTree().getSize();
-  }
-
-  @Override
-  public void setReferenceSizeWhileInitializing(Dimension size) {
-    //_setRefSize(size);
-    //
-    //if (size != null) {
-    //  todo consulo.ide.impl.idea.ui.tree.AsyncTreeModelTest.invokeWhenProcessingDone() //
-    //  myAbstractTreeBuilder.getReady(this).doWhenDone(() -> _setRefSize(null));
-    //}
-  }
-
-  //private void _setRefSize(Dimension size) {
-  //  JTree tree = getTree();
-  //  tree.setPreferredSize(size);
-  //  tree.setMinimumSize(size);
-  //  tree.setMaximumSize(size);
-  //
-  //  tree.revalidate();
-  //  tree.repaint();
-  //}
-
-  private static int getMinimumExpandDepth(StructureViewModel structureViewModel) {
-    StructureViewModel.ExpandInfoProvider provider =
-      ObjectUtil.tryCast(structureViewModel, StructureViewModel.ExpandInfoProvider.class);
-
-    return provider == null ? 2 : provider.getMinimumAutoExpandDepth();
-  }
-
-  private static class MyNodeWrapper extends TreeElementWrapper implements NodeDescriptorProvidingKey, ValidateableNode {
-
-    private long childrenStamp = -1;
-    private int modificationCountForChildren = ourSettingsModificationCount.get();
-
-    MyNodeWrapper(Project project, TreeElement value, TreeModel treeModel) {
-      super(project, value, treeModel);
-    }
-
-    @Override
-   
-    public Object getKey() {
-      StructureViewTreeElement element = (StructureViewTreeElement)getValue();
-      if (element instanceof NodeDescriptorProvidingKey) return ((NodeDescriptorProvidingKey)element).getKey();
-      Object value = element == null ? null : element.getValue();
-      return value == null ? this : value;
-    }
-
-    @RequiredReadAction
-    @Override
-   
-    public Collection<AbstractTreeNode> getChildren() {
-      if (ourSettingsModificationCount.get() != modificationCountForChildren) {
-        resetChildren();
-        modificationCountForChildren = ourSettingsModificationCount.get();
-      }
-
-      Object o = unwrapElement(getValue());
-      long currentStamp = -1;
-      if (o instanceof PsiElement) {
-        if (!((PsiElement)o).isValid()) return Collections.emptyList();
-
-        PsiFile file = ((PsiElement)o).getContainingFile();
-        if (file != null) {
-          currentStamp = file.getModificationStamp();
+    public void centerSelectedRow() {
+        TreePath path = getTree().getSelectionPath();
+        if (path == null) {
+            return;
         }
-      }
-      else if (o instanceof ModificationTracker) {
-        currentStamp = ((ModificationTracker)o).getModificationCount();
-      }
-      if (childrenStamp != currentStamp) {
-        resetChildren();
-        childrenStamp = currentStamp;
-      }
-      try {
-        return super.getChildren();
-      }
-      catch (IndexNotReadyException ignore) {
-        return Collections.emptyList();
-      }
+
+        myAutoScrollToSourceHandler.setShouldAutoScroll(false);
+        TreeUtil.showRowCentered(getTree(), getTree().getRowForPath(path), false);
+        myAutoScrollToSourceHandler.setShouldAutoScroll(true);
     }
 
     @Override
-    public boolean isAlwaysShowPlus() {
-      StructureViewModel.ElementInfoProvider elementInfoProvider = getElementInfoProvider();
-      return elementInfoProvider == null || elementInfoProvider.isAlwaysShowsPlus((StructureViewTreeElement)getValue());
-    }
+    @RequiredUIAccess
+    public void setActionActive(String name, boolean state) {
+        UIAccess.assertIsUIThread();
+        storeState();
+        StructureViewFactoryEx.getInstanceEx(myProject).setActiveAction(name, state);
+        ourSettingsModificationCount.incrementAndGet();
 
-    @Override
-    public boolean isAlwaysLeaf() {
-      StructureViewModel.ElementInfoProvider elementInfoProvider = getElementInfoProvider();
-      return elementInfoProvider != null && elementInfoProvider.isAlwaysLeaf((StructureViewTreeElement)getValue());
-    }
-
-    private StructureViewModel.@Nullable ElementInfoProvider getElementInfoProvider() {
-      if (myTreeModel instanceof StructureViewModel.ElementInfoProvider) {
-        return (StructureViewModel.ElementInfoProvider)myTreeModel;
-      }
-      if (myTreeModel instanceof TreeModelWrapper) {
-        StructureViewModel model = ((TreeModelWrapper)myTreeModel).getModel();
-        if (model instanceof StructureViewModel.ElementInfoProvider) {
-          return (StructureViewModel.ElementInfoProvider)model;
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            waitForRebuildAndExpand();
         }
-      }
-
-      return null;
-    }
-
-   
-    @Override
-    protected TreeElementWrapper createChildNode(TreeElement child) {
-      return new MyNodeWrapper(myProject, child, myTreeModel);
-    }
-
-   
-    @Override
-    protected GroupWrapper createGroupWrapper(Project project, Group group, TreeModel treeModel) {
-      return new MyGroupWrapper(project, group, treeModel);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (o instanceof MyNodeWrapper) {
-        return Comparing.equal(unwrapElement(getValue()), unwrapElement(((MyNodeWrapper)o).getValue()));
-      }
-      if (o instanceof StructureViewTreeElement) {
-        return Comparing.equal(unwrapElement(getValue()), ((StructureViewTreeElement)o).getValue());
-      }
-      return false;
-    }
-
-    @Override
-    public boolean isValid() {
-      TreeElement value = getValue();
-      PsiTreeElementBase psi = value instanceof PsiTreeElementBase ? (PsiTreeElementBase)value : null;
-      return psi == null || psi.isValid();
-    }
-
-    @Override
-    public int hashCode() {
-      Object o = unwrapElement(getValue());
-
-      return o != null ? o.hashCode() : 0;
-    }
-  }
-
-  private static class MyGroupWrapper extends GroupWrapper {
-    MyGroupWrapper(Project project, Group group, TreeModel treeModel) {
-      super(project, group, treeModel);
-    }
-
-   
-    @Override
-    protected TreeElementWrapper createChildNode(TreeElement child) {
-      return new MyNodeWrapper(getProject(), child, myTreeModel);
-    }
-
-   
-    @Override
-    protected GroupWrapper createGroupWrapper(Project project, Group group, TreeModel treeModel) {
-      return new MyGroupWrapper(project, group, treeModel);
-    }
-
-    @Override
-    public boolean isAlwaysShowPlus() {
-      return true;
-    }
-  }
-
-  private static class MyTree extends DnDAwareTree implements PlaceProvider<String> {
-    MyTree(javax.swing.tree.TreeModel model) {
-      super(model);
-      HintUpdateSupply.installDataContextHintUpdateSupply(this);
-    }
-
-    @Override
-    public String getPlace() {
-      return ActionPlaces.STRUCTURE_VIEW_TOOLBAR;
-    }
-
-    @Override
-    public void processMouseEvent(MouseEvent event) {
-      IdeEventQueueProxy.getInstance().requestFocusInNonFocusedWindow(event);
-      super.processMouseEvent(event);
-    }
-  }
-
-  private static class MyPsiTreeChangeListener extends PsiTreeChangeAdapter {
-    final PsiModificationTracker modTracker;
-    long prevModCount;
-    final Runnable onChange;
-
-    private MyPsiTreeChangeListener(PsiModificationTracker modTracker, Runnable onChange) {
-      this.modTracker = modTracker;
-      this.onChange = onChange;
-      prevModCount = modTracker.getModificationCount();
-    }
-
-    @Override
-    public void childRemoved(PsiTreeChangeEvent event) {
-      PsiElement child = event.getOldChild();
-      if (child instanceof PsiWhiteSpace) return; //optimization
-
-      childrenChanged();
-    }
-
-    @Override
-    public void childAdded(PsiTreeChangeEvent event) {
-      PsiElement child = event.getNewChild();
-      if (child instanceof PsiWhiteSpace) return; //optimization
-      childrenChanged();
-    }
-
-    @Override
-    public void childReplaced(PsiTreeChangeEvent event) {
-      PsiElement oldChild = event.getOldChild();
-      PsiElement newChild = event.getNewChild();
-      if (oldChild instanceof PsiWhiteSpace && newChild instanceof PsiWhiteSpace) return; //optimization
-      childrenChanged();
-    }
-
-    @Override
-    public void childMoved(PsiTreeChangeEvent event) {
-      childrenChanged();
-    }
-
-    @Override
-    public void childrenChanged(PsiTreeChangeEvent event) {
-      childrenChanged();
-    }
-
-    private void childrenChanged() {
-      long newModificationCount = modTracker.getModificationCount();
-      if (newModificationCount == prevModCount) return;
-      prevModCount = newModificationCount;
-      onChange.run();
-    }
-
-    @Override
-    public void propertyChanged(PsiTreeChangeEvent event) {
-      childrenChanged();
-    }
-  }
-
-  public static Object unwrapValue(Object o) {
-    return unwrapElement(unwrapWrapper(o));
-  }
-
-  public static @Nullable Object unwrapNavigatable(Object o) {
-    Object p = TreeUtil.getUserObject(o);
-    return p instanceof FilteringTreeStructure.FilteringNode ? ((FilteringTreeStructure.FilteringNode)p).getDelegate() : p;
-  }
-
-  public static Object unwrapWrapper(Object o) {
-    Object p = unwrapNavigatable(o);
-    return p instanceof MyNodeWrapper ? ((MyNodeWrapper)p).getValue() : p instanceof MyGroupWrapper ? ((MyGroupWrapper)p).getValue() : p;
-  }
-
-  private static Object unwrapElement(Object o) {
-    return o instanceof StructureViewTreeElement ? ((StructureViewTreeElement)o).getValue() : o;
-  }
-
-  // for FileStructurePopup only
- 
-  public static TreeElementWrapper createWrapper(Project project, TreeElement value, TreeModel treeModel) {
-    return new MyNodeWrapper(project, value, treeModel);
-  }
-
-  private static class MyExpandListener extends TreeModelAdapter {
-    private static final RegistryValue autoExpandDepth = Registry.get("ide.tree.autoExpandMaxDepth");
-
-    private final JTree tree;
-    final StructureViewModel.ExpandInfoProvider provider;
-    final boolean smartExpand;
-
-    MyExpandListener(JTree tree, StructureViewModel.@Nullable ExpandInfoProvider provider) {
-      this.tree = tree;
-      this.provider = provider;
-      smartExpand = provider != null && provider.isSmartExpand();
-    }
-
-    @Override
-    public void treeNodesInserted(TreeModelEvent e) {
-      TreePath parentPath = e.getTreePath();
-      if (Boolean.TRUE.equals(UIUtil.getClientProperty(tree, STRUCTURE_VIEW_STATE_RESTORED_KEY))) return;
-      if (parentPath == null || parentPath.getPathCount() > autoExpandDepth.asInteger() - 1) return;
-      Object[] children = e.getChildren();
-      if (smartExpand && children.length == 1) {
-        expandLater(parentPath, children[0]);
-      }
-      else {
-        for (Object o : children) {
-          NodeDescriptor descriptor = TreeUtil.getUserObject(NodeDescriptor.class, o);
-          if (descriptor != null && isAutoExpandNode(descriptor)) {
-            expandLater(parentPath, o);
-          }
+        else {
+            rebuild();
+            TreeUtil.expand(getTree(), getMinimumExpandDepth(myTreeModel));
         }
-      }
     }
 
-    void expandLater(TreePath parentPath, Object o) {
-      ApplicationManager.getApplication().invokeLater(() -> {
-        if (!tree.isVisible(parentPath) || !tree.isExpanded(parentPath)) return;
-        tree.expandPath(parentPath.pathByAddingChild(o));
-      });
+    @SuppressWarnings("TestOnlyProblems")
+    private void waitForRebuildAndExpand() {
+        wait(rebuildAndUpdate());
+        UIUtil.dispatchAllInvocationEvents();
+        wait(TreeUtil.promiseExpand(getTree(), getMinimumExpandDepth(myTreeModel)));
     }
 
-    boolean isAutoExpandNode(NodeDescriptor nodeDescriptor) {
-      if (provider != null) {
-        Object value = unwrapWrapper(nodeDescriptor.getElement());
-        if (value instanceof CustomRegionTreeElement) {
-          return true;
-        }
-        else if (value instanceof StructureViewTreeElement) {
-          return provider.isAutoExpand((StructureViewTreeElement)value);
-        }
-        else if (value instanceof GroupWrapper) {
-          Group group = ObjectUtil.notNull(((GroupWrapper)value).getValue());
-          for (TreeElement treeElement : group.getChildren()) {
-            if (treeElement instanceof StructureViewTreeElement && !provider.isAutoExpand((StructureViewTreeElement)treeElement)) {
-              return false;
+    private static void wait(Promise<?> originPromise) {
+        AtomicBoolean complete = new AtomicBoolean(false);
+        Promise<?> promise = originPromise.onProcessed(ignore -> complete.set(true));
+        while (!complete.get()) {
+            //noinspection TestOnlyProblems
+            UIUtil.dispatchAllInvocationEvents();
+            try {
+                promise.blockingGet(10, TimeUnit.MILLISECONDS);
             }
-          }
+            catch (Exception ignore) {
+            }
         }
-      }
-      // expand root node & its immediate children
-      NodeDescriptor parent = nodeDescriptor.getParentDescriptor();
-      return parent == null || parent.getParentDescriptor() == null;
     }
-  }
+
+    @Override
+    public boolean isActionActive(String name) {
+        return !myProject.isDisposed() && StructureViewFactoryEx.getInstanceEx(myProject).isActionActive(name);
+    }
+
+    private final class MyAutoScrollToSourceHandler extends AutoScrollToSourceHandler {
+        private boolean myShouldAutoScroll = true;
+
+        void setShouldAutoScroll(boolean shouldAutoScroll) {
+            myShouldAutoScroll = shouldAutoScroll;
+        }
+
+        @Override
+        protected boolean isAutoScrollMode() {
+            return myShouldAutoScroll && !myProject.isDisposed() && getSettings().AUTOSCROLL_MODE;
+        }
+
+        @Override
+        protected void setAutoScrollMode(boolean state) {
+            getSettings().AUTOSCROLL_MODE = state;
+        }
+
+        @Override
+        @RequiredReadAction
+        protected void scrollToSource(Component tree) {
+            if (isDisposed()) {
+                return;
+            }
+            myAutoscrollFeedback = true;
+
+            Navigable navigable = DataManager.getInstance().getDataContext(getTree()).getData(Navigable.KEY);
+            if (myFileEditor != null && navigable != null && navigable.canNavigateToSource()) {
+                navigable.navigate(false);
+            }
+        }
+    }
+
+    private class MyAutoScrollFromSourceHandler extends AutoScrollFromSourceHandler {
+        private FileEditorPositionListener myFileEditorPositionListener;
+
+        private MyAutoScrollFromSourceHandler(Project project, Disposable parentDisposable) {
+            super(project, getTree(), parentDisposable);
+        }
+
+        @Override
+        public void install() {
+            addEditorCaretListener();
+        }
+
+        @Override
+        public void dispose() {
+            super.dispose();
+            if (myFileEditorPositionListener != null) {
+                myTreeModel.removeEditorPositionListener(myFileEditorPositionListener);
+            }
+        }
+
+        private void addEditorCaretListener() {
+            myFileEditorPositionListener = () -> scrollToSelectedElement();
+            myTreeModel.addEditorPositionListener(myFileEditorPositionListener);
+
+            if (isAutoScrollEnabled()) {
+                //otherwise on any tab switching selection will be staying at the top file node until we made a first caret move
+                scrollToSelectedElement();
+            }
+        }
+
+        @Override
+        protected boolean isAutoScrollEnabled() {
+            return getSettings().AUTOSCROLL_FROM_SOURCE;
+        }
+
+        @Override
+        protected void setAutoScrollEnabled(boolean state) {
+            getSettings().AUTOSCROLL_FROM_SOURCE = state;
+            FileEditor[] selectedEditors = FileEditorManager.getInstance(myProject).getSelectedEditors();
+            if (selectedEditors.length > 0 && state) {
+                scrollToSelectedElementInner();
+            }
+        }
+    }
+
+    @Override
+    public Object getData(Key dataId) {
+        if (PsiElement.KEY == dataId) {
+            PsiElement element = getSelectedValues().filter(PsiElement.class).single();
+            return element != null && element.isValid() ? element : null;
+        }
+        if (PsiElement.KEY_OF_ARRAY == dataId) {
+            return PsiUtilCore.toPsiElementArray(getSelectedValues().filter(PsiElement.class).toList());
+        }
+        if (FileEditor.KEY == dataId) {
+            return myFileEditor;
+        }
+        if (CutProvider.KEY == dataId) {
+            return myCopyPasteDelegator.getCutProvider();
+        }
+        if (CopyProvider.KEY == dataId) {
+            return myCopyPasteDelegator.getCopyProvider();
+        }
+        if (PasteProvider.KEY == dataId) {
+            return myCopyPasteDelegator.getPasteProvider();
+        }
+        if (Navigable.KEY == dataId) {
+            List<Object> list = JBIterable.of(getTree().getSelectionPaths())
+                .map(TreePath::getLastPathComponent)
+                .map(StructureViewComponent::unwrapNavigable)
+                .toList();
+            Object[] selectedElements = list.isEmpty() ? null : ArrayUtil.toObjectArray(list);
+            if (selectedElements == null || selectedElements.length == 0) {
+                return null;
+            }
+            if (selectedElements[0] instanceof Navigable navigable) {
+                return navigable;
+            }
+        }
+        if (HelpManager.HELP_ID == dataId) {
+            return getHelpID();
+        }
+        if (Project.KEY == dataId) {
+            return myProject;
+        }
+        return super.getData(dataId);
+    }
+
+    @Override
+
+    public StructureViewModel getTreeModel() {
+        return myTreeModel;
+    }
+
+    @Override
+    public boolean navigateToSelectedElement(boolean requestFocus) {
+        select(myTreeModel.getCurrentEditorElement(), requestFocus);
+        return true;
+    }
+
+    @TestOnly
+    public AsyncPromise<Void> rebuildAndUpdate() {
+        AsyncPromise<Void> result = new AsyncPromise<>();
+        rebuild();
+        TreeVisitor visitor = path -> {
+            AbstractTreeNode node = TreeUtil.getLastUserObject(AbstractTreeNode.class, path);
+            if (node != null) {
+                node.update();
+            }
+            return TreeVisitor.Action.CONTINUE;
+        };
+        myAsyncTreeModel.accept(visitor).onProcessed(ignore -> result.setResult(null));
+        return result;
+    }
+
+    public String getHelpID() {
+        return "StructureView";
+    }
+
+    @Override
+    public Dimension getCurrentSize() {
+        return getTree().getSize();
+    }
+
+    @Override
+    public void setReferenceSizeWhileInitializing(Dimension size) {
+        //_setRefSize(size);
+        //
+        //if (size != null) {
+        //  todo consulo.ide.impl.idea.ui.tree.AsyncTreeModelTest.invokeWhenProcessingDone() //
+        //  myAbstractTreeBuilder.getReady(this).doWhenDone(() -> _setRefSize(null));
+        //}
+    }
+
+    //private void _setRefSize(Dimension size) {
+    //  JTree tree = getTree();
+    //  tree.setPreferredSize(size);
+    //  tree.setMinimumSize(size);
+    //  tree.setMaximumSize(size);
+    //
+    //  tree.revalidate();
+    //  tree.repaint();
+    //}
+
+    private static int getMinimumExpandDepth(StructureViewModel structureViewModel) {
+        StructureViewModel.ExpandInfoProvider provider =
+            ObjectUtil.tryCast(structureViewModel, StructureViewModel.ExpandInfoProvider.class);
+
+        return provider == null ? 2 : provider.getMinimumAutoExpandDepth();
+    }
+
+    private static class MyNodeWrapper extends TreeElementWrapper implements NodeDescriptorProvidingKey, ValidateableNode {
+
+        private long childrenStamp = -1;
+        private int modificationCountForChildren = ourSettingsModificationCount.get();
+
+        MyNodeWrapper(Project project, TreeElement value, TreeModel treeModel) {
+            super(project, value, treeModel);
+        }
+
+        @Override
+
+        public Object getKey() {
+            StructureViewTreeElement element = (StructureViewTreeElement) getValue();
+            if (element instanceof NodeDescriptorProvidingKey) {
+                return ((NodeDescriptorProvidingKey) element).getKey();
+            }
+            Object value = element == null ? null : element.getValue();
+            return value == null ? this : value;
+        }
+
+        @RequiredReadAction
+        @Override
+
+        public Collection<AbstractTreeNode> getChildren() {
+            if (ourSettingsModificationCount.get() != modificationCountForChildren) {
+                resetChildren();
+                modificationCountForChildren = ourSettingsModificationCount.get();
+            }
+
+            Object o = unwrapElement(getValue());
+            long currentStamp = -1;
+            if (o instanceof PsiElement) {
+                if (!((PsiElement) o).isValid()) {
+                    return Collections.emptyList();
+                }
+
+                PsiFile file = ((PsiElement) o).getContainingFile();
+                if (file != null) {
+                    currentStamp = file.getModificationStamp();
+                }
+            }
+            else if (o instanceof ModificationTracker) {
+                currentStamp = ((ModificationTracker) o).getModificationCount();
+            }
+            if (childrenStamp != currentStamp) {
+                resetChildren();
+                childrenStamp = currentStamp;
+            }
+            try {
+                return super.getChildren();
+            }
+            catch (IndexNotReadyException ignore) {
+                return Collections.emptyList();
+            }
+        }
+
+        @Override
+        public boolean isAlwaysShowPlus() {
+            StructureViewModel.ElementInfoProvider elementInfoProvider = getElementInfoProvider();
+            return elementInfoProvider == null || elementInfoProvider.isAlwaysShowsPlus((StructureViewTreeElement) getValue());
+        }
+
+        @Override
+        public boolean isAlwaysLeaf() {
+            StructureViewModel.ElementInfoProvider elementInfoProvider = getElementInfoProvider();
+            return elementInfoProvider != null && elementInfoProvider.isAlwaysLeaf((StructureViewTreeElement) getValue());
+        }
+
+        private StructureViewModel.@Nullable ElementInfoProvider getElementInfoProvider() {
+            if (myTreeModel instanceof StructureViewModel.ElementInfoProvider) {
+                return (StructureViewModel.ElementInfoProvider) myTreeModel;
+            }
+            if (myTreeModel instanceof TreeModelWrapper) {
+                StructureViewModel model = ((TreeModelWrapper) myTreeModel).getModel();
+                if (model instanceof StructureViewModel.ElementInfoProvider) {
+                    return (StructureViewModel.ElementInfoProvider) model;
+                }
+            }
+
+            return null;
+        }
+
+
+        @Override
+        protected TreeElementWrapper createChildNode(TreeElement child) {
+            return new MyNodeWrapper(myProject, child, myTreeModel);
+        }
+
+
+        @Override
+        protected GroupWrapper createGroupWrapper(Project project, Group group, TreeModel treeModel) {
+            return new MyGroupWrapper(project, group, treeModel);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof MyNodeWrapper) {
+                return Comparing.equal(unwrapElement(getValue()), unwrapElement(((MyNodeWrapper) o).getValue()));
+            }
+            if (o instanceof StructureViewTreeElement) {
+                return Comparing.equal(unwrapElement(getValue()), ((StructureViewTreeElement) o).getValue());
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isValid() {
+            TreeElement value = getValue();
+            PsiTreeElementBase psi = value instanceof PsiTreeElementBase ? (PsiTreeElementBase) value : null;
+            return psi == null || psi.isValid();
+        }
+
+        @Override
+        public int hashCode() {
+            Object o = unwrapElement(getValue());
+
+            return o != null ? o.hashCode() : 0;
+        }
+    }
+
+    private static class MyGroupWrapper extends GroupWrapper {
+        MyGroupWrapper(Project project, Group group, TreeModel treeModel) {
+            super(project, group, treeModel);
+        }
+
+
+        @Override
+        protected TreeElementWrapper createChildNode(TreeElement child) {
+            return new MyNodeWrapper(getProject(), child, myTreeModel);
+        }
+
+
+        @Override
+        protected GroupWrapper createGroupWrapper(Project project, Group group, TreeModel treeModel) {
+            return new MyGroupWrapper(project, group, treeModel);
+        }
+
+        @Override
+        public boolean isAlwaysShowPlus() {
+            return true;
+        }
+    }
+
+    private static class MyTree extends DnDAwareTree implements PlaceProvider<String> {
+        MyTree(javax.swing.tree.TreeModel model) {
+            super(model);
+            HintUpdateSupply.installDataContextHintUpdateSupply(this);
+        }
+
+        @Override
+        public String getPlace() {
+            return ActionPlaces.STRUCTURE_VIEW_TOOLBAR;
+        }
+
+        @Override
+        public void processMouseEvent(MouseEvent event) {
+            IdeEventQueueProxy.getInstance().requestFocusInNonFocusedWindow(event);
+            super.processMouseEvent(event);
+        }
+    }
+
+    private static class MyPsiTreeChangeListener extends PsiTreeChangeAdapter {
+        final PsiModificationTracker modTracker;
+        long prevModCount;
+        final Runnable onChange;
+
+        private MyPsiTreeChangeListener(PsiModificationTracker modTracker, Runnable onChange) {
+            this.modTracker = modTracker;
+            this.onChange = onChange;
+            prevModCount = modTracker.getModificationCount();
+        }
+
+        @Override
+        public void childRemoved(PsiTreeChangeEvent event) {
+            PsiElement child = event.getOldChild();
+            if (child instanceof PsiWhiteSpace) {
+                return; //optimization
+            }
+
+            childrenChanged();
+        }
+
+        @Override
+        public void childAdded(PsiTreeChangeEvent event) {
+            PsiElement child = event.getNewChild();
+            if (child instanceof PsiWhiteSpace) {
+                return; //optimization
+            }
+            childrenChanged();
+        }
+
+        @Override
+        public void childReplaced(PsiTreeChangeEvent event) {
+            PsiElement oldChild = event.getOldChild();
+            PsiElement newChild = event.getNewChild();
+            if (oldChild instanceof PsiWhiteSpace && newChild instanceof PsiWhiteSpace) {
+                return; //optimization
+            }
+            childrenChanged();
+        }
+
+        @Override
+        public void childMoved(PsiTreeChangeEvent event) {
+            childrenChanged();
+        }
+
+        @Override
+        public void childrenChanged(PsiTreeChangeEvent event) {
+            childrenChanged();
+        }
+
+        private void childrenChanged() {
+            long newModificationCount = modTracker.getModificationCount();
+            if (newModificationCount == prevModCount) {
+                return;
+            }
+            prevModCount = newModificationCount;
+            onChange.run();
+        }
+
+        @Override
+        public void propertyChanged(PsiTreeChangeEvent event) {
+            childrenChanged();
+        }
+    }
+
+    public static Object unwrapValue(Object o) {
+        return unwrapElement(unwrapWrapper(o));
+    }
+
+    public static @Nullable Object unwrapNavigable(Object o) {
+        Object p = TreeUtil.getUserObject(o);
+        return p instanceof FilteringTreeStructure.FilteringNode filteringNode ? filteringNode.getDelegate() : p;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #unwrapNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public static @Nullable Object unwrapNavigatable(Object o) {
+        return unwrapNavigable(o);
+    }
+
+    public static Object unwrapWrapper(Object o) {
+        Object p = unwrapNavigable(o);
+        return switch (p) {
+            case null -> p;
+            case MyNodeWrapper nodeWrapper -> nodeWrapper.getValue();
+            case MyGroupWrapper groupWrapper -> groupWrapper.getValue();
+            default -> p;
+        };
+    }
+
+    private static Object unwrapElement(Object o) {
+        return o instanceof StructureViewTreeElement ? ((StructureViewTreeElement) o).getValue() : o;
+    }
+
+    // for FileStructurePopup only
+
+    public static TreeElementWrapper createWrapper(Project project, TreeElement value, TreeModel treeModel) {
+        return new MyNodeWrapper(project, value, treeModel);
+    }
+
+    private static class MyExpandListener extends TreeModelAdapter {
+        private static final RegistryValue autoExpandDepth = Registry.get("ide.tree.autoExpandMaxDepth");
+
+        private final JTree tree;
+        final StructureViewModel.ExpandInfoProvider provider;
+        final boolean smartExpand;
+
+        MyExpandListener(JTree tree, StructureViewModel.@Nullable ExpandInfoProvider provider) {
+            this.tree = tree;
+            this.provider = provider;
+            smartExpand = provider != null && provider.isSmartExpand();
+        }
+
+        @Override
+        public void treeNodesInserted(TreeModelEvent e) {
+            TreePath parentPath = e.getTreePath();
+            if (Boolean.TRUE.equals(UIUtil.getClientProperty(tree, STRUCTURE_VIEW_STATE_RESTORED_KEY))) {
+                return;
+            }
+            if (parentPath == null || parentPath.getPathCount() > autoExpandDepth.asInteger() - 1) {
+                return;
+            }
+            Object[] children = e.getChildren();
+            if (smartExpand && children.length == 1) {
+                expandLater(parentPath, children[0]);
+            }
+            else {
+                for (Object o : children) {
+                    NodeDescriptor descriptor = TreeUtil.getUserObject(NodeDescriptor.class, o);
+                    if (descriptor != null && isAutoExpandNode(descriptor)) {
+                        expandLater(parentPath, o);
+                    }
+                }
+            }
+        }
+
+        void expandLater(TreePath parentPath, Object o) {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (!tree.isVisible(parentPath) || !tree.isExpanded(parentPath)) {
+                    return;
+                }
+                tree.expandPath(parentPath.pathByAddingChild(o));
+            });
+        }
+
+        boolean isAutoExpandNode(NodeDescriptor nodeDescriptor) {
+            if (provider != null) {
+                Object value = unwrapWrapper(nodeDescriptor.getElement());
+                if (value instanceof CustomRegionTreeElement) {
+                    return true;
+                }
+                else if (value instanceof StructureViewTreeElement) {
+                    return provider.isAutoExpand((StructureViewTreeElement) value);
+                }
+                else if (value instanceof GroupWrapper) {
+                    Group group = ObjectUtil.notNull(((GroupWrapper) value).getValue());
+                    for (TreeElement treeElement : group.getChildren()) {
+                        if (treeElement instanceof StructureViewTreeElement && !provider.isAutoExpand((StructureViewTreeElement) treeElement)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            // expand root node & its immediate children
+            NodeDescriptor parent = nodeDescriptor.getParentDescriptor();
+            return parent == null || parent.getParentDescriptor() == null;
+        }
+    }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/util/FileStructurePopup.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/ide/util/FileStructurePopup.java
@@ -48,6 +48,7 @@ import consulo.language.psi.util.PsiTreeUtil;
 import consulo.localize.LocalizeValue;
 import consulo.logging.Logger;
 import consulo.navigation.LocationPresentation;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.platform.base.icon.PlatformIconGroup;
 import consulo.project.Project;
@@ -392,7 +393,7 @@ public class FileStructurePopup implements Disposable, TreeActionsOwner {
         TreePath[] deepestPath = {null};
         TreeVisitor visitor = path -> {
             Object last = path.getLastPathComponent();
-            Object userObject = StructureViewComponent.unwrapNavigatable(last);
+            Object userObject = StructureViewComponent.unwrapNavigable(last);
             Object value = StructureViewComponent.unwrapValue(last);
             if (Comparing.equal(value, element)
                 || userObject instanceof AbstractTreeNode abstractTreeNode && abstractTreeNode.canRepresent(element)) {
@@ -597,12 +598,12 @@ public class FileStructurePopup implements Disposable, TreeActionsOwner {
             if (PsiElement.KEY_OF_ARRAY == dataId) {
                 return PsiUtilCore.toPsiElementArray(getSelectedElements().filter(PsiElement.class).toList());
             }
-            if (Navigatable.KEY == dataId) {
-                return getSelectedElements().filter(Navigatable.class).first();
+            if (Navigable.KEY == dataId) {
+                return getSelectedElements().filter(Navigable.class).first();
             }
-            if (Navigatable.KEY_OF_ARRAY == dataId) {
-                List<Navigatable> result = getSelectedElements().filter(Navigatable.class).toList();
-                return result.isEmpty() ? null : result.toArray(new Navigatable[0]);
+            if (Navigable.KEY_OF_ARRAY == dataId) {
+                List<Navigable> result = getSelectedElements().filter(Navigable.class).toList();
+                return result.isEmpty() ? null : result.toArray(Navigatable[]::new);
             }
             if (LangDataKeys.POSITION_ADJUSTER_POPUP == dataId) {
                 return myPopup;
@@ -750,7 +751,7 @@ public class FileStructurePopup implements Disposable, TreeActionsOwner {
 
     private @Nullable AbstractTreeNode getSelectedNode() {
         TreePath path = myTree.getSelectionPath();
-        Object o = StructureViewComponent.unwrapNavigatable(path == null ? null : path.getLastPathComponent());
+        Object o = StructureViewComponent.unwrapNavigable(path == null ? null : path.getLastPathComponent());
         return o instanceof AbstractTreeNode treeNode ? treeNode : null;
     }
 

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/openapi/fileEditor/impl/http/HttpFileEditor.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/openapi/fileEditor/impl/http/HttpFileEditor.java
@@ -15,177 +15,174 @@
  */
 package consulo.ide.impl.idea.openapi.fileEditor.impl.http;
 
-import consulo.fileEditor.highlight.BackgroundEditorHighlighter;
-import consulo.fileEditor.TextEditor;
-import consulo.fileEditor.structureView.StructureViewBuilder;
 import consulo.codeEditor.Editor;
 import consulo.codeEditor.EditorFactory;
 import consulo.document.impl.DocumentImpl;
-import consulo.fileEditor.text.TextEditorState;
 import consulo.fileEditor.FileEditorLocation;
 import consulo.fileEditor.FileEditorState;
 import consulo.fileEditor.FileEditorStateLevel;
+import consulo.fileEditor.TextEditor;
+import consulo.fileEditor.highlight.BackgroundEditorHighlighter;
+import consulo.fileEditor.structureView.StructureViewBuilder;
+import consulo.fileEditor.text.TextEditorState;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.util.dataholder.Key;
 import consulo.util.dataholder.UserDataHolderBase;
 import consulo.virtualFileSystem.VirtualFile;
 import consulo.virtualFileSystem.http.HttpVirtualFile;
-import consulo.navigation.Navigatable;
+import kava.beans.PropertyChangeListener;
 import org.jspecify.annotations.Nullable;
 
 import javax.swing.*;
-import kava.beans.PropertyChangeListener;
 
 /**
  * @author nik
  */
 public class HttpFileEditor implements TextEditor {
-  private final UserDataHolderBase myUserDataHolder = new UserDataHolderBase();
-  private final RemoteFilePanel myPanel;
-  private Editor myMockTextEditor;
-  private final Project myProject;
+    private final UserDataHolderBase myUserDataHolder = new UserDataHolderBase();
+    private final RemoteFilePanel myPanel;
+    private Editor myMockTextEditor;
+    private final Project myProject;
 
-  public HttpFileEditor(Project project, HttpVirtualFile virtualFile) {
-    myProject = project;
-    myPanel = new RemoteFilePanel(project, virtualFile);
-  }
-
-  
-  public JComponent getComponent() {
-    return myPanel.getMainPanel();
-  }
-
-  public JComponent getPreferredFocusedComponent() {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.getPreferredFocusedComponent();
+    public HttpFileEditor(Project project, HttpVirtualFile virtualFile) {
+        myProject = project;
+        myPanel = new RemoteFilePanel(project, virtualFile);
     }
-    return myPanel.getMainPanel();
-  }
 
-  
-  public String getName() {
-    return "Http";
-  }
 
-  
-  public Editor getEditor() {
-    TextEditor fileEditor = myPanel.getFileEditor();
-    if (fileEditor != null) {
-      return fileEditor.getEditor();
+    public JComponent getComponent() {
+        return myPanel.getMainPanel();
     }
-    if (myMockTextEditor == null) {
-      myMockTextEditor = EditorFactory.getInstance().createViewer(new DocumentImpl(""), myProject);
+
+    public JComponent getPreferredFocusedComponent() {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            return textEditor.getPreferredFocusedComponent();
+        }
+        return myPanel.getMainPanel();
     }
-    return myMockTextEditor;
-  }
 
-  
-  public FileEditorState getState(FileEditorStateLevel level) {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.getState(level);
+    public String getName() {
+        return "Http";
     }
-    return new TextEditorState();
-  }
 
-  public void setState(FileEditorState state) {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      textEditor.setState(state);
+    public Editor getEditor() {
+        TextEditor fileEditor = myPanel.getFileEditor();
+        if (fileEditor != null) {
+            return fileEditor.getEditor();
+        }
+        if (myMockTextEditor == null) {
+            myMockTextEditor = EditorFactory.getInstance().createViewer(new DocumentImpl(""), myProject);
+        }
+        return myMockTextEditor;
     }
-  }
 
-  public boolean isModified() {
-    return false;
-  }
-
-  public boolean isValid() {
-    return true;
-  }
-
-  public void selectNotify() {
-    myPanel.selectNotify();
-  }
-
-  public void deselectNotify() {
-    myPanel.deselectNotify();
-  }
-
-  public void addPropertyChangeListener(PropertyChangeListener listener) {
-    myPanel.addPropertyChangeListener(listener);
-  }
-
-  public void removePropertyChangeListener(PropertyChangeListener listener) {
-    myPanel.removePropertyChangeListener(listener);
-  }
-
-  public BackgroundEditorHighlighter getBackgroundHighlighter() {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.getBackgroundHighlighter();
+    public FileEditorState getState(FileEditorStateLevel level) {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            return textEditor.getState(level);
+        }
+        return new TextEditorState();
     }
-    return null;
-  }
 
-  public boolean canNavigateTo(Navigatable navigatable) {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.canNavigateTo(navigatable);
+    public void setState(FileEditorState state) {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            textEditor.setState(state);
+        }
     }
-    return false;
-  }
 
-  public void navigateTo(Navigatable navigatable) {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      textEditor.navigateTo(navigatable);
+    public boolean isModified() {
+        return false;
     }
-  }
 
-  public <T> T getUserData(Key<T> key) {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.getUserData(key);
+    public boolean isValid() {
+        return true;
     }
-    return myUserDataHolder.getUserData(key);
-  }
 
-  public <T> void putUserData(Key<T> key, @Nullable T value) {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      textEditor.putUserData(key, value);
+    public void selectNotify() {
+        myPanel.selectNotify();
     }
-    else {
-      myUserDataHolder.putUserData(key, value);
-    }
-  }
 
-  public FileEditorLocation getCurrentLocation() {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.getCurrentLocation();
+    public void deselectNotify() {
+        myPanel.deselectNotify();
     }
-    return null;
-  }
 
-  public StructureViewBuilder getStructureViewBuilder() {
-    TextEditor textEditor = myPanel.getFileEditor();
-    if (textEditor != null) {
-      return textEditor.getStructureViewBuilder();
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        myPanel.addPropertyChangeListener(listener);
     }
-    return null;
-  }
 
-  @Override
-  public @Nullable VirtualFile getFile() {
-    return null;
-  }
-
-  public void dispose() {
-    if (myMockTextEditor != null) {
-      EditorFactory.getInstance().releaseEditor(myMockTextEditor);
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        myPanel.removePropertyChangeListener(listener);
     }
-    myPanel.dispose();
-  }
+
+    public BackgroundEditorHighlighter getBackgroundHighlighter() {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            return textEditor.getBackgroundHighlighter();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean canNavigateTo(Navigable navigable) {
+        TextEditor textEditor = myPanel.getFileEditor();
+        return textEditor != null && textEditor.canNavigateTo(navigable);
+    }
+
+    @Override
+    public void navigateTo(Navigable navigable) {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            textEditor.navigateTo(navigable);
+        }
+    }
+
+    @Override
+    public <T> T getUserData(Key<T> key) {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            return textEditor.getUserData(key);
+        }
+        return myUserDataHolder.getUserData(key);
+    }
+
+    public <T> void putUserData(Key<T> key, @Nullable T value) {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            textEditor.putUserData(key, value);
+        }
+        else {
+            myUserDataHolder.putUserData(key, value);
+        }
+    }
+
+    public FileEditorLocation getCurrentLocation() {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            return textEditor.getCurrentLocation();
+        }
+        return null;
+    }
+
+    public StructureViewBuilder getStructureViewBuilder() {
+        TextEditor textEditor = myPanel.getFileEditor();
+        if (textEditor != null) {
+            return textEditor.getStructureViewBuilder();
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable VirtualFile getFile() {
+        return null;
+    }
+
+    public void dispose() {
+        if (myMockTextEditor != null) {
+            EditorFactory.getInstance().releaseEditor(myMockTextEditor);
+        }
+        myPanel.dispose();
+    }
 }

--- a/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/testIntegration/GotoTestOrCodeHandler.java
+++ b/modules/base/ide-impl/src/main/java/consulo/ide/impl/idea/testIntegration/GotoTestOrCodeHandler.java
@@ -13,30 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package consulo.ide.impl.idea.testIntegration;
 
-import consulo.language.editor.CodeInsightBundle;
+import consulo.codeEditor.Editor;
+import consulo.execution.executor.DefaultRunExecutor;
 import consulo.ide.impl.idea.codeInsight.navigation.GotoTargetHandler;
+import consulo.ide.impl.idea.openapi.keymap.KeymapUtil;
+import consulo.language.editor.CodeInsightBundle;
 import consulo.language.editor.testIntegration.TestCreator;
 import consulo.language.editor.testIntegration.TestFinderHelper;
 import consulo.language.editor.ui.PopupNavigationUtil;
-import consulo.execution.executor.DefaultRunExecutor;
-import consulo.platform.base.icon.PlatformIconGroup;
-import consulo.ui.ex.action.Shortcut;
-import consulo.codeEditor.Editor;
-import consulo.ui.ex.keymap.Keymap;
-import consulo.ui.ex.keymap.KeymapManager;
-import consulo.ide.impl.idea.openapi.keymap.KeymapUtil;
-import consulo.project.Project;
-import consulo.navigation.Navigatable;
 import consulo.language.psi.PsiElement;
 import consulo.language.psi.PsiFile;
 import consulo.language.psi.PsiUtilCore;
-import consulo.util.collection.SmartList;
+import consulo.navigation.Navigable;
+import consulo.platform.base.icon.PlatformIconGroup;
+import consulo.project.Project;
+import consulo.ui.annotation.RequiredUIAccess;
+import consulo.ui.ex.action.Shortcut;
+import consulo.ui.ex.keymap.Keymap;
+import consulo.ui.ex.keymap.KeymapManager;
 import consulo.ui.image.Image;
-
+import consulo.util.collection.SmartList;
 import org.jspecify.annotations.Nullable;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -85,7 +85,6 @@ public class GotoTestOrCodeHandler extends GotoTargetHandler {
     return new GotoData(sourceElement, PsiUtilCore.toPsiElementArray(candidates), actions);
   }
 
-  
   public static PsiElement getSelectedElement(Editor editor, PsiFile file) {
     return PsiUtilCore.getElementAtOffset(file, editor.getCaretModel().getOffset());
   }
@@ -95,7 +94,6 @@ public class GotoTestOrCodeHandler extends GotoTargetHandler {
     return false;
   }
 
-  
   @Override
   protected String getChooserTitle(PsiElement sourceElement, String name, int length, boolean finished) {
     String suffix = finished ? "" : " so far";
@@ -107,7 +105,6 @@ public class GotoTestOrCodeHandler extends GotoTargetHandler {
     }
   }
 
-  
   @Override
   protected String getFindUsagesTitle(PsiElement sourceElement, String name, int length) {
     if (TestFinderHelper.isTest(sourceElement)) {
@@ -118,7 +115,6 @@ public class GotoTestOrCodeHandler extends GotoTargetHandler {
     }
   }
 
-  
   @Override
   protected String getNotFoundMessage(Project project, Editor editor, PsiFile file) {
     return CodeInsightBundle.message("goto.test.notFound");
@@ -137,7 +133,8 @@ public class GotoTestOrCodeHandler extends GotoTargetHandler {
   }
 
   @Override
-  protected void navigateToElement(Navigatable element) {
+  @RequiredUIAccess
+  protected void navigateToElement(Navigable element) {
     if (element instanceof PsiElement) {
       PopupNavigationUtil.activateFileWithPsiElement((PsiElement)element, true);
     }

--- a/modules/base/language-api/src/main/java/consulo/language/psi/NavigablePsiElement.java
+++ b/modules/base/language-api/src/main/java/consulo/language/psi/NavigablePsiElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2009 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package consulo.navigation;
+package consulo.language.psi;
 
-import consulo.annotation.DeprecationInfo;
+import consulo.navigation.NavigationItem;
 
-@Deprecated
-@DeprecationInfo("Use NonNavigable, typo-corrected name")
-@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
-public final class NonNavigatable extends NonNavigable {
-    NonNavigatable() {
-    }
+/**
+ * @author yole
+ */
+public interface NavigablePsiElement extends PsiElement, NavigationItem {
+    NavigablePsiElement[] EMPTY_ARRAY = new NavigablePsiElement[0];
 }

--- a/modules/base/language-api/src/main/java/consulo/language/psi/NavigatablePsiElement.java
+++ b/modules/base/language-api/src/main/java/consulo/language/psi/NavigatablePsiElement.java
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package consulo.language.psi;
 
-import consulo.navigation.NavigationItem;
+import consulo.annotation.DeprecationInfo;
 
 /**
  * @author yole
  */
-public interface NavigatablePsiElement extends PsiElement, NavigationItem {
+@Deprecated
+@DeprecationInfo("Use NavigablePsiElement, typo-corrected name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+public interface NavigatablePsiElement extends NavigablePsiElement {
   NavigatablePsiElement[] EMPTY_ARRAY = new NavigatablePsiElement[0];
 }

--- a/modules/base/language-editor-api/src/main/java/consulo/language/editor/inspection/ProblemDescriptorBase.java
+++ b/modules/base/language-editor-api/src/main/java/consulo/language/editor/inspection/ProblemDescriptorBase.java
@@ -15,6 +15,7 @@
  */
 package consulo.language.editor.inspection;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.annotation.access.RequiredReadAction;
 import consulo.colorScheme.TextAttributesKey;
 import consulo.document.Document;
@@ -25,6 +26,7 @@ import consulo.language.psi.*;
 import consulo.language.psi.util.PsiTreeUtil;
 import consulo.localize.LocalizeValue;
 import consulo.logging.Logger;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 
@@ -33,12 +35,11 @@ import org.jspecify.annotations.Nullable;
 public class ProblemDescriptorBase extends CommonProblemDescriptorBase implements ProblemDescriptor {
     private static final Logger LOG = Logger.getInstance(ProblemDescriptorBase.class);
 
-    
     private final SmartPsiElementPointer myStartSmartPointer;
     private final @Nullable SmartPsiElementPointer myEndSmartPointer;
 
     private final ProblemHighlightType myHighlightType;
-    private Navigatable myNavigatable;
+    private Navigable myNavigable;
     private final boolean myAfterEndOfLine;
     private final TextRange myTextRangeInElement;
     private final boolean myShowTooltip;
@@ -218,12 +219,26 @@ public class ProblemDescriptorBase extends CommonProblemDescriptorBase implement
         return new TextRange(textRange.getStartOffset(), endElement.getTextRange().getEndOffset());
     }
 
-    public Navigatable getNavigatable() {
-        return myNavigatable;
+    public Navigable getNavigable() {
+        return myNavigable;
     }
 
-    public void setNavigatable(Navigatable navigatable) {
-        myNavigatable = navigatable;
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public Navigatable getNavigatable() {
+        return (Navigatable) myNavigable;
+    }
+
+    public void setNavigable(Navigable navigable) {
+        myNavigable = navigable;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #setNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public void setNavigatable(Navigable navigable) {
+        myNavigable = navigable;
     }
 
     @Override

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/Navigable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/Navigable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package consulo.navigation;
+
+import consulo.annotation.access.RequiredReadAction;
+import consulo.ui.annotation.RequiredUIAccess;
+import consulo.util.dataholder.Key;
+
+/**
+ * @author UNV
+ * @since 2026-06-11
+ */
+public interface Navigable {
+    Navigable[] EMPTY_ARRAY = new Navigable[0];
+
+    static Key<Navigatable> KEY = Key.create(Navigatable.class);
+
+    static Key<Navigatable[]> KEY_OF_ARRAY = Key.create(Navigatable[].class);
+
+    /**
+     * Open editor and select/navigate to the object there if possible.
+     * Just do nothing if navigation is not possible like in case of a package
+     *
+     * @param requestFocus <code>true</code> if focus requesting is necessary
+     */
+    @RequiredUIAccess
+    void navigate(boolean requestFocus);
+
+    /**
+     * @return <code>false</code> if navigation is not possible for any reason.
+     */
+    @RequiredReadAction
+    default boolean canNavigate() {
+        return true;
+    }
+
+    /**
+     * @return <code>false</code> if navigation to source is not possible for any reason.
+     * Source means some kind of editor
+     */
+    @RequiredReadAction
+    default boolean canNavigateToSource() {
+        return canNavigate();
+    }
+}

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/NavigableWithText.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/NavigableWithText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2010 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package consulo.navigation;
 
-import consulo.annotation.DeprecationInfo;
+import consulo.localize.LocalizeValue;
+import consulo.navigation.Navigatable;
 
-@Deprecated
-@DeprecationInfo("Use NonNavigable, typo-corrected name")
-@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
-public final class NonNavigatable extends NonNavigable {
-    NonNavigatable() {
-    }
+/**
+ * @author yole
+ */
+public interface NavigableWithText extends Navigatable {
+    LocalizeValue getNavigateActionText(boolean focusEditor);
 }

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/Navigatable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/Navigatable.java
@@ -15,39 +15,11 @@
  */
 package consulo.navigation;
 
-import consulo.annotation.access.RequiredReadAction;
-import consulo.util.dataholder.Key;
+import consulo.annotation.DeprecationInfo;
 
-public interface Navigatable {
-  Navigatable[] EMPTY_ARRAY = new Navigatable[0];
-
-  static Key<Navigatable> KEY = Key.create(Navigatable.class);
-
-  static Key<Navigatable[]> KEY_OF_ARRAY = Key.create(Navigatable[].class);
-
-  /**
-   * Open editor and select/navigate to the object there if possible.
-   * Just do nothing if navigation is not possible like in case of a package
-   *
-   * @param requestFocus <code>true</code> if focus requesting is necessary
-   */
-  @RequiredReadAction
-  void navigate(boolean requestFocus);
-
-  /**
-   * @return <code>false</code> if navigation is not possible for any reason.
-   */
-  @RequiredReadAction
-  default boolean canNavigate() {
-    return true;
-  }
-
-  /**
-   * @return <code>false</code> if navigation to source is not possible for any reason.
-   * Source means some kind of editor
-   */
-  @RequiredReadAction
-  default boolean canNavigateToSource() {
-    return canNavigate();
-  }
+@Deprecated
+@DeprecationInfo("Use Navigable, typo-corrected class name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+public interface Navigatable extends Navigable {
+    Navigatable[] EMPTY_ARRAY = new Navigatable[0];
 }

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/NavigatableWithText.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/NavigatableWithText.java
@@ -15,13 +15,13 @@
  */
 package consulo.navigation;
 
-import consulo.localize.LocalizeValue;
-import consulo.navigation.Navigatable;
+import consulo.annotation.DeprecationInfo;
 
 /**
  * @author yole
  */
-public interface NavigatableWithText extends Navigatable {
-    
-    LocalizeValue getNavigateActionText(boolean focusEditor);
+@Deprecated
+@DeprecationInfo("Use NavigableWithText, typo-corrected name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+public interface NavigatableWithText extends NavigableWithText {
 }

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/NonNavigable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/NonNavigable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package consulo.navigation;
+
+import consulo.annotation.access.RequiredReadAction;
+import consulo.ui.annotation.RequiredUIAccess;
+
+/**
+ * Implementation of {@link Navigable} interface which actually doesn't allow navigation. Its {@link #INSTANCE} can be passed to methods which
+ * expect non-null instance of {@link Navigable} if you cannot provide a real implementation.
+ */
+@SuppressWarnings("deprecation")
+public abstract sealed class NonNavigable implements Navigatable permits NonNavigatable {
+    public static final Navigable INSTANCE = new NonNavigatable();
+
+    @Override
+    @RequiredUIAccess
+    public void navigate(boolean requestFocus) {
+    }
+
+    @Override
+    @RequiredReadAction
+    public boolean canNavigate() {
+        return false;
+    }
+
+    @Override
+    @RequiredReadAction
+    public boolean canNavigateToSource() {
+        return false;
+    }
+}
+

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2013 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,15 @@
  */
 package consulo.navigation;
 
-import consulo.annotation.DeprecationInfo;
+import consulo.annotation.access.RequiredReadAction;
 
-@Deprecated
-@DeprecationInfo("Use NonNavigable, typo-corrected name")
-@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
-public final class NonNavigatable extends NonNavigable {
-    NonNavigatable() {
-    }
+/**
+ * Navigable that saves cursor position in the editor when navigating to
+ * already opened documents
+ *
+ * @author Konstantin Bulenkov
+ */
+public interface StatePreservingNavigable extends Navigatable {
+    @RequiredReadAction
+    void navigate(boolean requestFocus, boolean preserveState);
 }

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigatable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigatable.java
@@ -16,7 +16,6 @@
 package consulo.navigation;
 
 import consulo.annotation.DeprecationInfo;
-import consulo.annotation.access.RequiredReadAction;
 
 /**
  * Navigable that saves cursor position in the editor when navigating to
@@ -28,6 +27,4 @@ import consulo.annotation.access.RequiredReadAction;
 @DeprecationInfo("Use StatePreservingNavigable, typo-corrected class name")
 @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
 public interface StatePreservingNavigatable extends StatePreservingNavigable {
-    @RequiredReadAction
-    void navigate(boolean requestFocus, boolean preserveState);
 }

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigatable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigatable.java
@@ -21,6 +21,7 @@ package consulo.navigation;
  *
  * @author Konstantin Bulenkov
  */
-public interface StatePreservingNavigatable extends Navigatable {
-  void navigate(boolean requestFocus, boolean preserveState);
+public interface StatePreservingNavigatable extends StatePreservingNavigable {
+    @Override
+    void navigate(boolean requestFocus, boolean preserveState);
 }

--- a/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigatable.java
+++ b/modules/base/navigation-api/src/main/java/consulo/navigation/StatePreservingNavigatable.java
@@ -15,13 +15,19 @@
  */
 package consulo.navigation;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.annotation.access.RequiredReadAction;
+
 /**
- * Navigatable that saves cursor position in the editor when navigating to
+ * Navigable that saves cursor position in the editor when navigating to
  * already opened documents
  *
  * @author Konstantin Bulenkov
  */
+@Deprecated
+@DeprecationInfo("Use StatePreservingNavigable, typo-corrected class name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
 public interface StatePreservingNavigatable extends StatePreservingNavigable {
-    @Override
+    @RequiredReadAction
     void navigate(boolean requestFocus, boolean preserveState);
 }

--- a/modules/base/ui-ex-api/src/main/java/consulo/ui/ex/OccurenceNavigator.java
+++ b/modules/base/ui-ex-api/src/main/java/consulo/ui/ex/OccurenceNavigator.java
@@ -15,82 +15,91 @@
  */
 package consulo.ui.ex;
 
+import consulo.annotation.DeprecationInfo;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 
 public interface OccurenceNavigator {
-  OccurenceNavigator EMPTY = new OccurenceNavigator() {
-    @Override
-    public boolean hasNextOccurence() {
-      return false;
+    OccurenceNavigator EMPTY = new OccurenceNavigator() {
+        @Override
+        public boolean hasNextOccurence() {
+            return false;
+        }
+
+        @Override
+        public boolean hasPreviousOccurence() {
+            return false;
+        }
+
+        @Override
+        public OccurenceInfo goNextOccurence() {
+            return null;
+        }
+
+        @Override
+        public OccurenceInfo goPreviousOccurence() {
+            return null;
+        }
+
+        @Override
+        public String getNextOccurenceActionName() {
+            return "";
+        }
+
+        @Override
+        public String getPreviousOccurenceActionName() {
+            return "";
+        }
+    };
+
+    class OccurenceInfo {
+        private final Navigable myNavigable;
+        private final int myOccurrenceNumber;
+        private final int myOccurrencesCount;
+
+        public OccurenceInfo(Navigable navigable, int occurrenceNumber, int occurrencesCount) {
+            myNavigable = navigable;
+            myOccurrenceNumber = occurrenceNumber;
+            myOccurrencesCount = occurrencesCount;
+        }
+
+        private OccurenceInfo(int occurrenceNumber, int occurrencesCount) {
+            this(null, occurrenceNumber, occurrencesCount);
+        }
+
+        public static OccurenceInfo position(int occurrenceNumber, int occurrencesCount) {
+            return new OccurenceInfo(occurrenceNumber, occurrencesCount);
+        }
+
+        public Navigable getNavigable() {
+            return myNavigable;
+        }
+
+        @Deprecated
+        @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+        @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+        public Navigatable getNavigateable() {
+            return (Navigatable) getNavigable();
+        }
+
+        public int getOccurenceNumber() {
+            return myOccurrenceNumber;
+        }
+
+        public int getOccurencesCount() {
+            return myOccurrencesCount;
+        }
     }
 
-    @Override
-    public boolean hasPreviousOccurence() {
-      return false;
-    }
+    boolean hasNextOccurence();
 
-    @Override
-    public OccurenceInfo goNextOccurence() {
-      return null;
-    }
+    boolean hasPreviousOccurence();
 
-    @Override
-    public OccurenceInfo goPreviousOccurence() {
-      return null;
-    }
+    OccurenceInfo goNextOccurence();
 
-    @Override
-    public String getNextOccurenceActionName() {
-      return "";
-    }
+    OccurenceInfo goPreviousOccurence();
 
-    @Override
-    public String getPreviousOccurenceActionName() {
-      return "";
-    }
-  };
+    String getNextOccurenceActionName();
 
-  class OccurenceInfo {
-    private final Navigatable myNavigateable;
-    private final int myOccurrenceNumber;
-    private final int myOccurrencesCount;
-
-    public OccurenceInfo(Navigatable navigateable, int occurrenceNumber, int occurrencesCount) {
-      myNavigateable = navigateable;
-      myOccurrenceNumber = occurrenceNumber;
-      myOccurrencesCount = occurrencesCount;
-    }
-
-    private OccurenceInfo(int occurrenceNumber, int occurrencesCount) {
-      this(null, occurrenceNumber, occurrencesCount);
-    }
-
-    public static OccurenceInfo position(int occurrenceNumber, int occurrencesCount) {
-      return new OccurenceInfo(occurrenceNumber, occurrencesCount);
-    }
-
-    public Navigatable getNavigateable() {
-      return myNavigateable;
-    }
-
-    public int getOccurenceNumber() {
-      return myOccurrenceNumber;
-    }
-
-    public int getOccurencesCount() {
-      return myOccurrencesCount;
-    }
-  }
-
-  boolean hasNextOccurence();
-
-  boolean hasPreviousOccurence();
-
-  OccurenceInfo goNextOccurence();
-
-  OccurenceInfo goPreviousOccurence();
-
-  String getNextOccurenceActionName();
-
-  String getPreviousOccurenceActionName();
+    String getPreviousOccurenceActionName();
 }

--- a/modules/base/ui-ex-api/src/main/java/consulo/ui/ex/errorTreeView/ErrorTreeView.java
+++ b/modules/base/ui-ex-api/src/main/java/consulo/ui/ex/errorTreeView/ErrorTreeView.java
@@ -16,37 +16,46 @@
 package consulo.ui.ex.errorTreeView;
 
 import consulo.disposer.Disposable;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.util.dataholder.Key;
 import consulo.virtualFileSystem.VirtualFile;
-
 import org.jspecify.annotations.Nullable;
+
 import javax.swing.*;
 
 public interface ErrorTreeView extends Disposable {
-  Key<Object> CURRENT_EXCEPTION_DATA_KEY = Key.create("CURRENT_EXCEPTION_DATA");
+    Key<Object> CURRENT_EXCEPTION_DATA_KEY = Key.create("CURRENT_EXCEPTION_DATA");
 
-  /**
-   * If file is not null, allows to navigate to this file, line, column
-   */
-  void addMessage(int type, String[] text, @Nullable VirtualFile file, int line, int column, @Nullable Object data);
+    /**
+     * If file is not null, allows to navigate to this file, line, column
+     */
+    void addMessage(int type, String[] text, @Nullable VirtualFile file, int line, int column, @Nullable Object data);
 
-  /**
-   * Allows adding messages related to other files under 'underFileGroup'
-   */
-  void addMessage(int type, String[] text, @Nullable VirtualFile underFileGroup, @Nullable VirtualFile file, int line, int column, @Nullable Object data);
+    /**
+     * Allows adding messages related to other files under 'underFileGroup'
+     */
+    void addMessage(
+        int type,
+        String[] text,
+        @Nullable VirtualFile underFileGroup,
+        @Nullable VirtualFile file,
+        int line,
+        int column,
+        @Nullable Object data
+    );
 
-  /**
-   * add message, allowing navigation via custom Navigatable object
-   */
-  void addMessage(int type,
-                  String[] text,
-                  @Nullable String groupName,
-                  Navigatable navigatable,
-                  @Nullable String exportTextPrefix,
-                  @Nullable String rendererTextPrefix,
-                  @Nullable Object data);
+    /**
+     * add message, allowing navigation via custom Navigable object
+     */
+    void addMessage(
+        int type,
+        String[] text,
+        @Nullable String groupName,
+        Navigable navigable,
+        @Nullable String exportTextPrefix,
+        @Nullable String rendererTextPrefix,
+        @Nullable Object data
+    );
 
-  
-  JComponent getComponent();
+    JComponent getComponent();
 }

--- a/modules/base/ui-ex-awt-api/src/main/java/consulo/ui/ex/awt/tree/Navigable.java
+++ b/modules/base/ui-ex-awt-api/src/main/java/consulo/ui/ex/awt/tree/Navigable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package consulo.navigation;
+package consulo.ui.ex.awt.tree;
 
-import consulo.annotation.DeprecationInfo;
+import consulo.util.concurrent.Promise;
 
-@Deprecated
-@DeprecationInfo("Use NonNavigable, typo-corrected name")
-@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
-public final class NonNavigatable extends NonNavigable {
-    NonNavigatable() {
-    }
+import javax.swing.tree.TreePath;
+
+/**
+ * @author Sergey.Malenkov
+ */
+public interface Navigable {
+    Promise<TreePath> nextTreePath(TreePath path, Object object);
+
+    Promise<TreePath> prevTreePath(TreePath path, Object object);
 }

--- a/modules/base/ui-ex-awt-api/src/main/java/consulo/ui/ex/awt/tree/Navigatable.java
+++ b/modules/base/ui-ex-awt-api/src/main/java/consulo/ui/ex/awt/tree/Navigatable.java
@@ -15,17 +15,13 @@
  */
 package consulo.ui.ex.awt.tree;
 
-import consulo.util.concurrent.Promise;
-
-import javax.swing.tree.TreePath;
+import consulo.annotation.DeprecationInfo;
 
 /**
  * @author Sergey.Malenkov
  */
-public interface Navigatable {
-  
-  Promise<TreePath> nextTreePath(TreePath path, Object object);
-
-  
-  Promise<TreePath> prevTreePath(TreePath path, Object object);
+@Deprecated
+@DeprecationInfo("Use Navigable, typo-corrected name")
+@SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+public interface Navigatable extends Navigable {
 }

--- a/modules/base/ui-ex-awt-api/src/main/java/consulo/ui/ex/awt/tree/TreeUtil.java
+++ b/modules/base/ui-ex-awt-api/src/main/java/consulo/ui/ex/awt/tree/TreeUtil.java
@@ -2,6 +2,7 @@
 package consulo.ui.ex.awt.tree;
 
 import com.uber.nullaway.annotations.Contract;
+import consulo.annotation.DeprecationInfo;
 import consulo.application.Application;
 import consulo.application.ApplicationManager;
 import consulo.application.ui.UISettings;
@@ -11,6 +12,7 @@ import consulo.application.util.registry.Registry;
 import consulo.awt.hacking.BasicTreeUIHacking;
 import consulo.component.ComponentManager;
 import consulo.logging.Logger;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.ui.UIAccess;
 import consulo.ui.ex.RelativePoint;
@@ -55,7 +57,7 @@ public final class TreeUtil {
     private static final String TREE_UTIL_SCROLL_TIME_STAMP = "TreeUtil.scrollTimeStamp";
     private static final JBIterable<Integer> NUMBERS = JBIterable.generate(0, i -> i + 1);
     private static final Key<Function<TreePath, Navigatable>> NAVIGATABLE_PROVIDER =
-        Key.create("TreeUtil: convert TreePath to Navigatable");
+        Key.create("TreeUtil: convert TreePath to Navigable");
 
     private TreeUtil() {
     }
@@ -1935,15 +1937,25 @@ public final class TreeUtil {
     }
 
     /**
-     * @return a navigatable object that corresponds to the specified path,  or {@code null} otherwise
+     * @return a navigable object that corresponds to the specified path,  or {@code null} otherwise
      */
-    public static @Nullable Navigatable getNavigatable(JTree tree, @Nullable TreePath path) {
+    public static @Nullable Navigable getNavigable(JTree tree, @Nullable TreePath path) {
         Function<? super TreePath, ? extends Navigatable> supplier = UIUtil.getClientProperty(tree, NAVIGATABLE_PROVIDER);
-        return supplier != null ? supplier.apply(path) : getLastUserObject(Navigatable.class, path);
+        return supplier != null ? supplier.apply(path) : getLastUserObject(Navigable.class, path);
     }
 
     /**
-     * Sets the mapping function that provides a navigatable object for a tree path.
+     * @return a navigatable object that corresponds to the specified path,  or {@code null} otherwise
+     */
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    public static @Nullable Navigatable getNavigatable(JTree tree, @Nullable TreePath path) {
+        return (@Nullable Navigatable) getNavigable(tree, path);
+    }
+
+    /**
+     * Sets the mapping function that provides a navigable object for a tree path.
      */
     public static void setNavigatableProvider(JTree tree, Function<? super TreePath, ? extends Navigatable> provider) {
         tree.putClientProperty(NAVIGATABLE_PROVIDER, provider);

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/action/OpenInEditorAction.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/action/OpenInEditorAction.java
@@ -15,6 +15,7 @@
  */
 package consulo.desktop.awt.internal.diff.action;
 
+import consulo.annotation.access.RequiredReadAction;
 import consulo.application.ReadAction;
 import consulo.application.dumb.DumbAware;
 import consulo.diff.DiffContext;
@@ -23,6 +24,7 @@ import consulo.diff.DiffUserDataKeys;
 import consulo.diff.internal.DiffImplUtil;
 import consulo.diff.request.DiffRequest;
 import consulo.ide.impl.idea.ide.actions.EditSourceAction;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.ui.annotation.RequiredUIAccess;
@@ -34,69 +36,77 @@ import consulo.util.dataholder.Key;
 import org.jspecify.annotations.Nullable;
 
 public class OpenInEditorAction extends EditSourceAction implements DumbAware {
-  public static final Key<OpenInEditorAction> KEY = Key.create("DiffOpenInEditorAction");
+    public static final Key<OpenInEditorAction> KEY = Key.create("DiffOpenInEditorAction");
 
-  private final @Nullable Runnable myAfterRunnable;
+    private final @Nullable Runnable myAfterRunnable;
 
-  public OpenInEditorAction(@Nullable Runnable afterRunnable) {
-    ActionUtil.copyFrom(this, IdeActions.ACTION_EDIT_SOURCE);
-    myAfterRunnable = afterRunnable;
-  }
-
-  @Override
-  public void update(AnActionEvent e) {
-    if (!e.isFromActionToolbar()) {
-      e.getPresentation().setEnabledAndVisible(true);
-      return;
+    public OpenInEditorAction(@Nullable Runnable afterRunnable) {
+        ActionUtil.copyFrom(this, IdeActions.ACTION_EDIT_SOURCE);
+        myAfterRunnable = afterRunnable;
     }
 
-    DiffRequest request = e.getData(DiffDataKeys.DIFF_REQUEST);
-    DiffContext context = e.getData(DiffDataKeys.DIFF_CONTEXT);
+    @Override
+    public void update(AnActionEvent e) {
+        if (!e.isFromActionToolbar()) {
+            e.getPresentation().setEnabledAndVisible(true);
+            return;
+        }
 
-    if (DiffImplUtil.isUserDataFlagSet(DiffUserDataKeys.GO_TO_SOURCE_DISABLE, request, context)) {
-      e.getPresentation().setEnabledAndVisible(false);
+        DiffRequest request = e.getData(DiffDataKeys.DIFF_REQUEST);
+        DiffContext context = e.getData(DiffDataKeys.DIFF_CONTEXT);
+
+        if (DiffImplUtil.isUserDataFlagSet(DiffUserDataKeys.GO_TO_SOURCE_DISABLE, request, context)) {
+            e.getPresentation().setEnabledAndVisible(false);
+        }
+
+        if (e.getData(Project.KEY) == null) {
+            e.getPresentation().setVisible(true);
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+
+        Navigatable[] navigatables = ReadAction.compute(() -> e.getData(DiffDataKeys.NAVIGABLE_ARRAY));
+        if (navigatables == null || !ContainerUtil.exists(navigatables, Navigable::canNavigate)) {
+            e.getPresentation().setVisible(true);
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+
+        e.getPresentation().setEnabledAndVisible(true);
     }
 
-    if (e.getData(Project.KEY) == null) {
-      e.getPresentation().setVisible(true);
-      e.getPresentation().setEnabled(false);
-      return;
+    @Override
+    @RequiredUIAccess
+    public void actionPerformed(AnActionEvent e) {
+        Project project = e.getData(Project.KEY);
+        if (project == null) {
+            return;
+        }
+
+        Navigatable[] navigatables = e.getData(DiffDataKeys.NAVIGABLE_ARRAY);
+        if (navigatables == null) {
+            return;
+        }
+
+        openEditor(project, navigatables);
     }
 
-    Navigatable[] navigatables = ReadAction.compute(() -> e.getData(DiffDataKeys.NAVIGATABLE_ARRAY));
-    if (navigatables == null || !ContainerUtil.exists(navigatables, Navigatable::canNavigate)) {
-      e.getPresentation().setVisible(true);
-      e.getPresentation().setEnabled(false);
-      return;
+    @RequiredReadAction
+    public void openEditor(Project project, Navigable navigable) {
+        openEditor(project, new Navigatable[]{(Navigatable) navigable});
     }
 
-    e.getPresentation().setEnabledAndVisible(true);
-  }
-
-  @RequiredUIAccess
-  @Override
-  public void actionPerformed(AnActionEvent e) {
-    Project project = e.getData(Project.KEY);
-    if (project == null) return;
-
-    Navigatable[] navigatables = e.getData(DiffDataKeys.NAVIGATABLE_ARRAY);
-    if (navigatables == null) return;
-
-    openEditor(project, navigatables);
-  }
-
-  public void openEditor(Project project, Navigatable navigatable) {
-    openEditor(project, new Navigatable[]{navigatable});
-  }
-
-  public void openEditor(Project project, Navigatable[] navigatables) {
-    boolean success = false;
-    for (Navigatable navigatable : navigatables) {
-      if (navigatable.canNavigate()) {
-        navigatable.navigate(true);
-        success = true;
-      }
+    @RequiredReadAction
+    public void openEditor(Project project, Navigatable[] navigatables) {
+        boolean success = false;
+        for (Navigable navigable : navigatables) {
+            if (navigable.canNavigate()) {
+                navigable.navigate(true);
+                success = true;
+            }
+        }
+        if (success && myAfterRunnable != null) {
+            myAfterRunnable.run();
+        }
     }
-    if (success && myAfterRunnable != null) myAfterRunnable.run();
-  }
 }

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/action/OpenInEditorWithMouseAction.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/action/OpenInEditorWithMouseAction.java
@@ -15,10 +15,12 @@
  */
 package consulo.desktop.awt.internal.diff.action;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.codeEditor.Editor;
 import consulo.codeEditor.event.EditorMouseEventArea;
 import consulo.codeEditor.EditorGutterComponentEx;
 import consulo.application.dumb.DumbAware;
+import consulo.navigation.Navigable;
 import consulo.project.Project;
 import consulo.navigation.Navigatable;
 import consulo.ui.annotation.RequiredUIAccess;
@@ -34,86 +36,95 @@ import java.util.Collections;
 import java.util.List;
 
 public abstract class OpenInEditorWithMouseAction extends AnAction implements DumbAware {
-  
-  private List<? extends Editor> myEditors = Collections.emptyList();
 
-  public OpenInEditorWithMouseAction() {
-    AnAction navigateAction = ActionManager.getInstance().getAction(IdeActions.ACTION_GOTO_DECLARATION); // null in MPS
-    setShortcutSet(navigateAction != null ?
-                   navigateAction.getShortcutSet() :
-                   new CustomShortcutSet(new MouseShortcut(MouseEvent.BUTTON1, InputEvent.CTRL_DOWN_MASK, 1)));
-  }
+    private List<? extends Editor> myEditors = Collections.emptyList();
 
-  public void install(List<? extends Editor> editors) {
-    myEditors = editors;
-    for (Editor editor : editors) {
-      registerCustomShortcutSet(getShortcutSet(), ((EditorGutterComponentEx)editor.getGutter()).getComponent());
-    }
-  }
-
-  @Override
-  public void update(AnActionEvent e) {
-    InputEvent inputEvent = e.getInputEvent();
-    Component component = inputEvent.getComponent();
-    if (!(inputEvent instanceof MouseEvent) || !e.hasData(Project.KEY) || !e.hasData(OpenInEditorAction.KEY) || component == null) {
-      e.getPresentation().setEnabledAndVisible(false);
-      return;
+    public OpenInEditorWithMouseAction() {
+        AnAction navigateAction = ActionManager.getInstance().getAction(IdeActions.ACTION_GOTO_DECLARATION); // null in MPS
+        setShortcutSet(navigateAction != null ?
+            navigateAction.getShortcutSet() :
+            new CustomShortcutSet(new MouseShortcut(MouseEvent.BUTTON1, InputEvent.CTRL_DOWN_MASK, 1)));
     }
 
-    Point point = ((MouseEvent)inputEvent).getPoint();
-    Component componentAt = SwingUtilities.getDeepestComponentAt(component, point.x, point.y);
-    if (!(componentAt instanceof EditorGutterComponentEx)) {
-      e.getPresentation().setEnabledAndVisible(false);
-      return;
+    public void install(List<? extends Editor> editors) {
+        myEditors = editors;
+        for (Editor editor : editors) {
+            registerCustomShortcutSet(getShortcutSet(), ((EditorGutterComponentEx) editor.getGutter()).getComponent());
+        }
     }
 
-    Editor editor = getEditor(componentAt);
-    if (editor == null) {
-      e.getPresentation().setEnabledAndVisible(false);
-      return;
+    @Override
+    public void update(AnActionEvent e) {
+        InputEvent inputEvent = e.getInputEvent();
+        Component component = inputEvent.getComponent();
+        if (!(inputEvent instanceof MouseEvent) || !e.hasData(Project.KEY) || !e.hasData(OpenInEditorAction.KEY) || component == null) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        Point point = ((MouseEvent) inputEvent).getPoint();
+        Component componentAt = SwingUtilities.getDeepestComponentAt(component, point.x, point.y);
+        if (!(componentAt instanceof EditorGutterComponentEx)) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        Editor editor = getEditor(componentAt);
+        if (editor == null) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        MouseEvent convertedEvent = SwingUtilities.convertMouseEvent(inputEvent.getComponent(), (MouseEvent) inputEvent, componentAt);
+        EditorMouseEventArea area = editor.getMouseEventArea(convertedEvent);
+        if (area != EditorMouseEventArea.LINE_NUMBERS_AREA) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        e.getPresentation().setEnabledAndVisible(true);
     }
 
-    MouseEvent convertedEvent = SwingUtilities.convertMouseEvent(inputEvent.getComponent(), (MouseEvent)inputEvent, componentAt);
-    EditorMouseEventArea area = editor.getMouseEventArea(convertedEvent);
-    if (area != EditorMouseEventArea.LINE_NUMBERS_AREA) {
-      e.getPresentation().setEnabledAndVisible(false);
-      return;
+    @Override
+    @RequiredUIAccess
+    public void actionPerformed(AnActionEvent e) {
+        MouseEvent inputEvent = (MouseEvent) e.getInputEvent();
+        OpenInEditorAction openInEditorAction = e.getRequiredData(OpenInEditorAction.KEY);
+        Project project = e.getRequiredData(Project.KEY);
+
+        Component component = inputEvent.getComponent();
+        Point point = inputEvent.getPoint();
+        Component componentAt = SwingUtilities.getDeepestComponentAt(component, point.x, point.y);
+        MouseEvent convertedEvent = SwingUtilities.convertMouseEvent(inputEvent.getComponent(), inputEvent, componentAt);
+
+        Editor editor = getEditor(componentAt);
+        assert editor != null;
+
+        int line = editor.xyToLogicalPosition(convertedEvent.getPoint()).line;
+
+        Navigable navigable = getNavigable(editor, line);
+        if (navigable == null) {
+            return;
+        }
+
+        openInEditorAction.openEditor(project, navigable);
     }
 
-    e.getPresentation().setEnabledAndVisible(true);
-  }
-
-  @Override
-  @RequiredUIAccess
-  public void actionPerformed(AnActionEvent e) {
-    MouseEvent inputEvent = (MouseEvent)e.getInputEvent();
-    OpenInEditorAction openInEditorAction = e.getRequiredData(OpenInEditorAction.KEY);
-    Project project = e.getRequiredData(Project.KEY);
-
-    Component component = inputEvent.getComponent();
-    Point point = inputEvent.getPoint();
-    Component componentAt = SwingUtilities.getDeepestComponentAt(component, point.x, point.y);
-    MouseEvent convertedEvent = SwingUtilities.convertMouseEvent(inputEvent.getComponent(), inputEvent, componentAt);
-
-    Editor editor = getEditor(componentAt);
-    assert editor != null;
-
-    int line = editor.xyToLogicalPosition(convertedEvent.getPoint()).line;
-
-    Navigatable navigatable = getNavigatable(editor, line);
-    if (navigatable == null) return;
-
-    openInEditorAction.openEditor(project, navigatable);
-  }
-
-  private @Nullable Editor getEditor(Component component) {
-    for (Editor editor : myEditors) {
-      if (editor != null && editor.getGutter() == component) {
-        return editor;
-      }
+    private @Nullable Editor getEditor(Component component) {
+        for (Editor editor : myEditors) {
+            if (editor != null && editor.getGutter() == component) {
+                return editor;
+            }
+        }
+        return null;
     }
-    return null;
-  }
 
-  protected abstract @Nullable Navigatable getNavigatable(Editor editor, int line);
+    protected abstract @Nullable Navigable getNavigable(Editor editor, int line);
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    protected @Nullable Navigatable getNavigatable(Editor editor, int line) {
+        return (Navigatable) getNavigable(editor, line);
+    }
 }

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/fragment/UnifiedDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/fragment/UnifiedDiffViewer.java
@@ -16,6 +16,7 @@
 package consulo.desktop.awt.internal.diff.fragment;
 
 import com.uber.nullaway.annotations.Contract;
+import consulo.annotation.DeprecationInfo;
 import consulo.annotation.access.RequiredWriteAction;
 import consulo.application.AccessRule;
 import consulo.application.AllIcons;
@@ -60,6 +61,7 @@ import consulo.document.event.DocumentAdapter;
 import consulo.document.event.DocumentEvent;
 import consulo.document.util.TextRange;
 import consulo.logging.Logger;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.ui.annotation.RequiredUIAccess;
@@ -982,8 +984,8 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
 
     @Override
     @RequiredUIAccess
-    protected @Nullable Navigatable getNavigatable() {
-        return getNavigatable(myEditor.getCaretModel().getOffset());
+    protected @Nullable Navigable getNavigable() {
+        return getNavigable(myEditor.getCaretModel().getOffset());
     }
 
     @RequiredUIAccess
@@ -1023,14 +1025,14 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
     }
 
     @RequiredUIAccess
-    protected @Nullable Navigatable getNavigatable(int offset) {
+    protected @Nullable Navigable getNavigable(int offset) {
         LogicalPosition position = myEditor.offsetToLogicalPosition(offset);
         Pair<int[], Side> pair = transferLineFromOneside(position.line);
         int line1 = pair.first[0];
         int line2 = pair.first[1];
 
-        Navigatable navigable1 = getContent1().getNavigatable(new LineCol(line1, position.column));
-        Navigatable navigable2 = getContent2().getNavigatable(new LineCol(line2, position.column));
+        Navigable navigable1 = getContent1().getNavigable(new LineCol(line1, position.column));
+        Navigable navigable2 = getContent2().getNavigable(new LineCol(line2, position.column));
         if (navigable1 == null) {
             return navigable2;
         }
@@ -1038,6 +1040,14 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
             return navigable1;
         }
         return pair.second.select(navigable1, navigable2);
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable(), typo-corrected name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    @RequiredUIAccess
+    protected @Nullable Navigatable getNavigatable(int offset) {
+        return (Navigatable) getNavigable(offset);
     }
 
     public static boolean canShowRequest(DiffContext context, DiffRequest request) {
@@ -1079,12 +1089,12 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
 
     private class MyOpenInEditorWithMouseAction extends OpenInEditorWithMouseAction {
         @Override
-        protected Navigatable getNavigatable(Editor editor, int line) {
+        protected Navigable getNavigable(Editor editor, int line) {
             if (editor != myEditor) {
                 return null;
             }
 
-            return getNavigatable(myEditor, line);
+            return getNavigable(myEditor, line);
         }
     }
 
@@ -1325,9 +1335,9 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
         private final @Nullable UnifiedEditorRangeHighlighter myRangeHighlighter;
         private final @Nullable FileType myFileType;
 
-        private final IntUnaryOperator myLineConvertor1;
+        private final IntUnaryOperator myLineConverter1;
 
-        private final IntUnaryOperator myLineConvertor2;
+        private final IntUnaryOperator myLineConverter2;
 
         public CombinedEditorData(
             CharSequence text,
@@ -1341,8 +1351,8 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
             myHighlighter = highlighter;
             myRangeHighlighter = rangeHighlighter;
             myFileType = fileType;
-            myLineConvertor1 = converter1;
-            myLineConvertor2 = converter2;
+            myLineConverter1 = converter1;
+            myLineConverter2 = converter2;
         }
 
         public CharSequence getText() {
@@ -1362,11 +1372,11 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase {
         }
 
         public IntUnaryOperator getLineConvertor1() {
-            return myLineConvertor1;
+            return myLineConverter1;
         }
 
         public IntUnaryOperator getLineConvertor2() {
-            return myLineConvertor2;
+            return myLineConverter2;
         }
     }
 

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/DiffViewerBase.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/DiffViewerBase.java
@@ -15,6 +15,7 @@
  */
 package consulo.desktop.awt.internal.diff.util;
 
+import consulo.annotation.DeprecationInfo;
 import consulo.application.Application;
 import consulo.application.impl.internal.progress.ProgressWindow;
 import consulo.application.progress.ProgressIndicator;
@@ -28,6 +29,7 @@ import consulo.diff.request.ContentDiffRequest;
 import consulo.disposer.Disposer;
 import consulo.ide.impl.idea.openapi.vcs.CalledInBackground;
 import consulo.logging.Logger;
+import consulo.navigation.Navigable;
 import consulo.navigation.Navigatable;
 import consulo.project.Project;
 import consulo.ui.UIAccess;
@@ -254,8 +256,15 @@ public abstract class DiffViewerBase implements DiffViewer, DataProvider {
         Disposer.dispose(myTaskAlarm);
     }
 
-    protected @Nullable Navigatable getNavigatable() {
+    protected @Nullable Navigable getNavigable() {
         return null;
+    }
+
+    @Deprecated
+    @DeprecationInfo("Use #getNavigable() with typo-fixed name")
+    @SuppressWarnings({"SpellCheckingInspection", "deprecation"})
+    protected @Nullable Navigatable getNavigatable() {
+        return (Navigatable) getNavigable();
     }
 
     //
@@ -307,8 +316,8 @@ public abstract class DiffViewerBase implements DiffViewer, DataProvider {
 
     @Override
     public @Nullable Object getData(Key<?> dataId) {
-        if (DiffDataKeys.NAVIGATABLE == dataId) {
-            return getNavigatable();
+        if (DiffDataKeys.NAVIGABLE == dataId) {
+            return getNavigable();
         }
         else if (Project.KEY == dataId) {
             return myProject;

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/ThreesideDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/ThreesideDiffViewer.java
@@ -15,6 +15,9 @@
  */
 package consulo.desktop.awt.internal.diff.util;
 
+import consulo.desktop.awt.internal.diff.EditorHolder;
+import consulo.desktop.awt.internal.diff.EditorHolderFactory;
+import consulo.desktop.awt.internal.diff.util.side.ThreesideContentPanel;
 import consulo.diff.DiffContext;
 import consulo.diff.DiffDataKeys;
 import consulo.diff.DiffDialogHints;
@@ -26,11 +29,8 @@ import consulo.diff.request.DiffRequest;
 import consulo.diff.request.SimpleDiffRequest;
 import consulo.diff.util.ThreeSide;
 import consulo.disposer.Disposer;
-import consulo.desktop.awt.internal.diff.EditorHolder;
-import consulo.desktop.awt.internal.diff.EditorHolderFactory;
-import consulo.desktop.awt.internal.diff.util.side.ThreesideContentPanel;
 import consulo.ide.impl.idea.openapi.actionSystem.ex.ActionImplUtil;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.AnActionEvent;
 import consulo.ui.ex.action.DumbAwareAction;
@@ -43,205 +43,218 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class ThreesideDiffViewer<T extends EditorHolder> extends ListenerDiffViewerBase {
-  
-  protected final SimpleDiffPanel myPanel;
-  
-  protected final ThreesideContentPanel myContentPanel;
 
-  
-  private final List<T> myHolders;
+    protected final SimpleDiffPanel myPanel;
 
-  
-  private final FocusTrackerSupport<ThreeSide> myFocusTrackerSupport;
+    protected final ThreesideContentPanel myContentPanel;
 
-  public ThreesideDiffViewer(DiffContext context, ContentDiffRequest request, EditorHolderFactory<T> factory) {
-    super(context, request);
 
-    myHolders = createEditorHolders(factory);
+    private final List<T> myHolders;
 
-    myFocusTrackerSupport = new FocusTrackerSupport.Threeside(myHolders);
-    myContentPanel = new ThreesideContentPanel.Holders(myHolders);
 
-    myPanel = new SimpleDiffPanel(myContentPanel, this, context);
-  }
+    private final FocusTrackerSupport<ThreeSide> myFocusTrackerSupport;
 
-  @RequiredUIAccess
-  @Override
-  protected void onInit() {
-    super.onInit();
-    myPanel.setPersistentNotifications(AWTDiffUtil.getCustomNotifications(myContext, myRequest));
-    myContentPanel.setTitles(createTitles());
-  }
+    public ThreesideDiffViewer(DiffContext context, ContentDiffRequest request, EditorHolderFactory<T> factory) {
+        super(context, request);
 
-  @Override
-  @RequiredUIAccess
-  protected void onDispose() {
-    destroyEditorHolders();
-    super.onDispose();
-  }
+        myHolders = createEditorHolders(factory);
 
-  @Override
-  @RequiredUIAccess
-  protected void processContextHints() {
-    super.processContextHints();
-    myFocusTrackerSupport.processContextHints(myRequest, myContext);
-  }
+        myFocusTrackerSupport = new FocusTrackerSupport.Threeside(myHolders);
+        myContentPanel = new ThreesideContentPanel.Holders(myHolders);
 
-  @Override
-  @RequiredUIAccess
-  protected void updateContextHints() {
-    super.updateContextHints();
-    myFocusTrackerSupport.updateContextHints(myRequest, myContext);
-  }
-
-  
-  protected List<T> createEditorHolders(EditorHolderFactory<T> factory) {
-    List<DiffContent> contents = myRequest.getContents();
-
-    List<T> holders = new ArrayList<>(3);
-    for (int i = 0; i < 3; i++) {
-      DiffContent content = contents.get(i);
-      holders.add(factory.create(content, myContext));
+        myPanel = new SimpleDiffPanel(myContentPanel, this, context);
     }
-    return holders;
-  }
 
-  private void destroyEditorHolders() {
-    for (T holder : myHolders) {
-      Disposer.dispose(holder);
-    }
-  }
-
-  
-  protected List<JComponent> createTitles() {
-    return AWTDiffUtil.createSyncHeightComponents(AWTDiffUtil.createSimpleTitles(myRequest));
-  }
-
-  //
-  // Getters
-  //
-
-  
-  @Override
-  public JComponent getComponent() {
-    return myPanel;
-  }
-
-  @Override
-  public @Nullable JComponent getPreferredFocusedComponent() {
-    if (!myPanel.isGoodContent()) return null;
-    return getCurrentEditorHolder().getPreferredFocusedComponent();
-  }
-
-  
-  public ThreeSide getCurrentSide() {
-    return myFocusTrackerSupport.getCurrentSide();
-  }
-
-  protected void setCurrentSide(ThreeSide side) {
-    myFocusTrackerSupport.setCurrentSide(side);
-  }
-
-  
-  protected List<T> getEditorHolders() {
-    return myHolders;
-  }
-
-  
-  protected T getCurrentEditorHolder() {
-    return getCurrentSide().select(getEditorHolders());
-  }
-
-  @Override
-  public @Nullable Object getData(Key<?> dataId) {
-    if (VirtualFile.KEY == dataId) {
-      return DiffImplUtil.getVirtualFile(myRequest, getCurrentSide());
-    }
-    else if (DiffDataKeys.CURRENT_CONTENT == dataId) {
-      return getCurrentSide().select(myRequest.getContents());
-    }
-    return super.getData(dataId);
-  }
-
-  //
-  // Misc
-  //
-
-  @Override
-  protected @Nullable Navigatable getNavigatable() {
-    return getCurrentSide().select(getRequest().getContents()).getNavigatable();
-  }
-
-  public static <T extends EditorHolder> boolean canShowRequest(DiffContext context,
-                                                                DiffRequest request,
-                                                                EditorHolderFactory<T> factory) {
-    if (!(request instanceof ContentDiffRequest)) return false;
-
-    List<DiffContent> contents = ((ContentDiffRequest)request).getContents();
-    if (contents.size() != 3) return false;
-
-    boolean canShow = true;
-    boolean wantShow = false;
-    for (DiffContent content : contents) {
-      canShow &= factory.canShowContent(content, context);
-      wantShow |= factory.wantShowContent(content, context);
-    }
-    return canShow && wantShow;
-  }
-
-  //
-  // Actions
-  //
-
-  protected enum PartialDiffMode {LEFT_BASE, BASE_RIGHT, LEFT_RIGHT}
-  protected class ShowPartialDiffAction extends DumbAwareAction {
-    
-    protected final ThreeSide mySide1;
-    
-    protected final ThreeSide mySide2;
-
-    public ShowPartialDiffAction(PartialDiffMode mode) {
-      String id;
-      switch (mode) {
-        case LEFT_BASE:
-          mySide1 = ThreeSide.LEFT;
-          mySide2 = ThreeSide.BASE;
-          id = "Diff.ComparePartial.Base.Left";
-          break;
-        case BASE_RIGHT:
-          mySide1 = ThreeSide.BASE;
-          mySide2 = ThreeSide.RIGHT;
-          id = "Diff.ComparePartial.Base.Right";
-          break;
-        case LEFT_RIGHT:
-          mySide1 = ThreeSide.LEFT;
-          mySide2 = ThreeSide.RIGHT;
-          id = "Diff.ComparePartial.Left.Right";
-          break;
-        default:
-          throw new IllegalArgumentException();
-      }
-      ActionImplUtil.copyFrom(this, id);
+    @RequiredUIAccess
+    @Override
+    protected void onInit() {
+        super.onInit();
+        myPanel.setPersistentNotifications(AWTDiffUtil.getCustomNotifications(myContext, myRequest));
+        myContentPanel.setTitles(createTitles());
     }
 
     @Override
     @RequiredUIAccess
-    public void actionPerformed(AnActionEvent e) {
-      DiffRequest request = createRequest();
-      DiffManager.getInstance().showDiff(myProject, request, new DiffDialogHints(null, myPanel));
+    protected void onDispose() {
+        destroyEditorHolders();
+        super.onDispose();
     }
 
-    
-    protected SimpleDiffRequest createRequest() {
-      List<DiffContent> contents = myRequest.getContents();
-      List<String> titles = myRequest.getContentTitles();
-      return new SimpleDiffRequest(
-        myRequest.getTitle(),
-        mySide1.select(contents),
-        mySide2.select(contents),
-        mySide1.select(titles),
-        mySide2.select(titles)
-      );
+    @Override
+    @RequiredUIAccess
+    protected void processContextHints() {
+        super.processContextHints();
+        myFocusTrackerSupport.processContextHints(myRequest, myContext);
     }
-  }
+
+    @Override
+    @RequiredUIAccess
+    protected void updateContextHints() {
+        super.updateContextHints();
+        myFocusTrackerSupport.updateContextHints(myRequest, myContext);
+    }
+
+
+    protected List<T> createEditorHolders(EditorHolderFactory<T> factory) {
+        List<DiffContent> contents = myRequest.getContents();
+
+        List<T> holders = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            DiffContent content = contents.get(i);
+            holders.add(factory.create(content, myContext));
+        }
+        return holders;
+    }
+
+    private void destroyEditorHolders() {
+        for (T holder : myHolders) {
+            Disposer.dispose(holder);
+        }
+    }
+
+
+    protected List<JComponent> createTitles() {
+        return AWTDiffUtil.createSyncHeightComponents(AWTDiffUtil.createSimpleTitles(myRequest));
+    }
+
+    //
+    // Getters
+    //
+
+
+    @Override
+    public JComponent getComponent() {
+        return myPanel;
+    }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        if (!myPanel.isGoodContent()) {
+            return null;
+        }
+        return getCurrentEditorHolder().getPreferredFocusedComponent();
+    }
+
+
+    public ThreeSide getCurrentSide() {
+        return myFocusTrackerSupport.getCurrentSide();
+    }
+
+    protected void setCurrentSide(ThreeSide side) {
+        myFocusTrackerSupport.setCurrentSide(side);
+    }
+
+
+    protected List<T> getEditorHolders() {
+        return myHolders;
+    }
+
+
+    protected T getCurrentEditorHolder() {
+        return getCurrentSide().select(getEditorHolders());
+    }
+
+    @Override
+    public @Nullable Object getData(Key<?> dataId) {
+        if (VirtualFile.KEY == dataId) {
+            return DiffImplUtil.getVirtualFile(myRequest, getCurrentSide());
+        }
+        else if (DiffDataKeys.CURRENT_CONTENT == dataId) {
+            return getCurrentSide().select(myRequest.getContents());
+        }
+        return super.getData(dataId);
+    }
+
+    //
+    // Misc
+    //
+
+    @Override
+    protected @Nullable Navigable getNavigable() {
+        return getCurrentSide().select(getRequest().getContents()).getNavigable();
+    }
+
+    public static <T extends EditorHolder> boolean canShowRequest(
+        DiffContext context,
+        DiffRequest request,
+        EditorHolderFactory<T> factory
+    ) {
+        if (!(request instanceof ContentDiffRequest contentDiffRequest)) {
+            return false;
+        }
+
+        List<DiffContent> contents = contentDiffRequest.getContents();
+        if (contents.size() != 3) {
+            return false;
+        }
+
+        boolean canShow = true;
+        boolean wantShow = false;
+        for (DiffContent content : contents) {
+            canShow &= factory.canShowContent(content, context);
+            wantShow |= factory.wantShowContent(content, context);
+        }
+        return canShow && wantShow;
+    }
+
+    //
+    // Actions
+    //
+
+    protected enum PartialDiffMode {
+        LEFT_BASE,
+        BASE_RIGHT,
+        LEFT_RIGHT
+    }
+
+    protected class ShowPartialDiffAction extends DumbAwareAction {
+
+        protected final ThreeSide mySide1;
+
+        protected final ThreeSide mySide2;
+
+        public ShowPartialDiffAction(PartialDiffMode mode) {
+            String id;
+            switch (mode) {
+                case LEFT_BASE:
+                    mySide1 = ThreeSide.LEFT;
+                    mySide2 = ThreeSide.BASE;
+                    id = "Diff.ComparePartial.Base.Left";
+                    break;
+                case BASE_RIGHT:
+                    mySide1 = ThreeSide.BASE;
+                    mySide2 = ThreeSide.RIGHT;
+                    id = "Diff.ComparePartial.Base.Right";
+                    break;
+                case LEFT_RIGHT:
+                    mySide1 = ThreeSide.LEFT;
+                    mySide2 = ThreeSide.RIGHT;
+                    id = "Diff.ComparePartial.Left.Right";
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+            ActionImplUtil.copyFrom(this, id);
+        }
+
+        @Override
+        @RequiredUIAccess
+        public void actionPerformed(AnActionEvent e) {
+            DiffRequest request = createRequest();
+            DiffManager.getInstance().showDiff(myProject, request, new DiffDialogHints(null, myPanel));
+        }
+
+
+        protected SimpleDiffRequest createRequest() {
+            List<DiffContent> contents = myRequest.getContents();
+            List<String> titles = myRequest.getContentTitles();
+            return new SimpleDiffRequest(
+                myRequest.getTitle(),
+                mySide1.select(contents),
+                mySide2.select(contents),
+                mySide1.select(titles),
+                mySide2.select(titles)
+            );
+        }
+    }
 }

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/OnesideDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/OnesideDiffViewer.java
@@ -29,7 +29,7 @@ import consulo.diff.request.ContentDiffRequest;
 import consulo.diff.request.DiffRequest;
 import consulo.diff.util.Side;
 import consulo.disposer.Disposer;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.util.dataholder.Key;
 import consulo.virtualFileSystem.VirtualFile;
@@ -39,128 +39,127 @@ import javax.swing.*;
 import java.util.List;
 
 public abstract class OnesideDiffViewer<T extends EditorHolder> extends ListenerDiffViewerBase {
-  
-  protected final SimpleDiffPanel myPanel;
-  
-  protected final OnesideContentPanel myContentPanel;
+    protected final SimpleDiffPanel myPanel;
 
-  
-  private final Side mySide;
-  
-  private final T myHolder;
+    protected final OnesideContentPanel myContentPanel;
 
-  public OnesideDiffViewer(DiffContext context, ContentDiffRequest request, EditorHolderFactory<T> factory) {
-    super(context, request);
+    private final Side mySide;
 
-    mySide = Side.fromRight(myRequest.getContents().get(0) instanceof EmptyContent);
-    myHolder = createEditorHolder(factory);
+    private final T myHolder;
 
-    myContentPanel = OnesideContentPanel.createFromHolder(myHolder);
+    public OnesideDiffViewer(DiffContext context, ContentDiffRequest request, EditorHolderFactory<T> factory) {
+        super(context, request);
 
-    myPanel = new SimpleDiffPanel(myContentPanel, this, context);
-  }
+        mySide = Side.fromRight(myRequest.getContents().get(0) instanceof EmptyContent);
+        myHolder = createEditorHolder(factory);
 
-  @Override
-  @RequiredUIAccess
-  protected void onInit() {
-    super.onInit();
-    myPanel.setPersistentNotifications(AWTDiffUtil.getCustomNotifications(myContext, myRequest));
-    myContentPanel.setTitle(createTitle());
-  }
+        myContentPanel = OnesideContentPanel.createFromHolder(myHolder);
 
-  @Override
-  @RequiredUIAccess
-  protected void onDispose() {
-    destroyEditorHolder();
-    super.onDispose();
-  }
-
-  //
-  // Editors
-  //
-
-  
-  protected T createEditorHolder(EditorHolderFactory<T> factory) {
-    DiffContent content = mySide.select(myRequest.getContents());
-    return factory.create(content, myContext);
-  }
-
-  private void destroyEditorHolder() {
-    Disposer.dispose(myHolder);
-  }
-
-  protected @Nullable JComponent createTitle() {
-    List<JComponent> simpleTitles = AWTDiffUtil.createSimpleTitles(myRequest);
-    return mySide.select(simpleTitles);
-  }
-
-  //
-  // Getters
-  //
-
-  
-  @Override
-  public JComponent getComponent() {
-    return myPanel;
-  }
-
-  @Override
-  public @Nullable JComponent getPreferredFocusedComponent() {
-    if (!myPanel.isGoodContent()) return null;
-    return getEditorHolder().getPreferredFocusedComponent();
-  }
-
-  
-  public Side getSide() {
-    return mySide;
-  }
-
-  
-  protected DiffContent getContent() {
-    return mySide.select(myRequest.getContents());
-  }
-
-  
-  protected T getEditorHolder() {
-    return myHolder;
-  }
-
-  @Override
-  public @Nullable Object getData(Key<?> dataId) {
-    if (VirtualFile.KEY == dataId) {
-      return DiffImplUtil.getVirtualFile(myRequest, mySide);
+        myPanel = new SimpleDiffPanel(myContentPanel, this, context);
     }
-    else if (DiffDataKeys.CURRENT_CONTENT == dataId) {
-      return getContent();
+
+    @Override
+    @RequiredUIAccess
+    protected void onInit() {
+        super.onInit();
+        myPanel.setPersistentNotifications(AWTDiffUtil.getCustomNotifications(myContext, myRequest));
+        myContentPanel.setTitle(createTitle());
     }
-    return super.getData(dataId);
-  }
 
-  //
-  // Misc
-  //
-
-  @Override
-  protected @Nullable Navigatable getNavigatable() {
-    return getContent().getNavigatable();
-  }
-
-  public static <T extends EditorHolder> boolean canShowRequest(
-    DiffContext context,
-    DiffRequest request,
-    EditorHolderFactory<T> factory
-  ) {
-    if (!(request instanceof ContentDiffRequest)) return false;
-
-    List<DiffContent> contents = ((ContentDiffRequest)request).getContents();
-    if (contents.size() != 2) return false;
-
-    DiffContent content1 = contents.get(0);
-    DiffContent content2 = contents.get(1);
-
-    if (content1 instanceof EmptyContent) {
-      return factory.canShowContent(content2, context) && factory.wantShowContent(content2, context);
+    @Override
+    @RequiredUIAccess
+    protected void onDispose() {
+        destroyEditorHolder();
+        super.onDispose();
     }
-    return content2 instanceof EmptyContent && factory.canShowContent(content1, context) && factory.wantShowContent(content1, context);
-  }
+
+    //
+    // Editors
+    //
+
+    protected T createEditorHolder(EditorHolderFactory<T> factory) {
+        DiffContent content = mySide.select(myRequest.getContents());
+        return factory.create(content, myContext);
+    }
+
+    private void destroyEditorHolder() {
+        Disposer.dispose(myHolder);
+    }
+
+    protected @Nullable JComponent createTitle() {
+        List<JComponent> simpleTitles = AWTDiffUtil.createSimpleTitles(myRequest);
+        return mySide.select(simpleTitles);
+    }
+
+    //
+    // Getters
+    //
+
+    @Override
+    public JComponent getComponent() {
+        return myPanel;
+    }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        if (!myPanel.isGoodContent()) {
+            return null;
+        }
+        return getEditorHolder().getPreferredFocusedComponent();
+    }
+
+    public Side getSide() {
+        return mySide;
+    }
+
+    protected DiffContent getContent() {
+        return mySide.select(myRequest.getContents());
+    }
+
+    protected T getEditorHolder() {
+        return myHolder;
+    }
+
+    @Override
+    public @Nullable Object getData(Key<?> dataId) {
+        if (VirtualFile.KEY == dataId) {
+            return DiffImplUtil.getVirtualFile(myRequest, mySide);
+        }
+        else if (DiffDataKeys.CURRENT_CONTENT == dataId) {
+            return getContent();
+        }
+        return super.getData(dataId);
+    }
+
+    //
+    // Misc
+    //
+
+    @Override
+    protected @Nullable Navigable getNavigable() {
+        return getContent().getNavigable();
+    }
+
+    public static <T extends EditorHolder> boolean canShowRequest(
+        DiffContext context,
+        DiffRequest request,
+        EditorHolderFactory<T> factory
+    ) {
+        if (!(request instanceof ContentDiffRequest contentDiffRequest)) {
+            return false;
+        }
+
+        List<DiffContent> contents = contentDiffRequest.getContents();
+        if (contents.size() != 2) {
+            return false;
+        }
+
+        DiffContent content1 = contents.get(0);
+        DiffContent content2 = contents.get(1);
+
+        if (content1 instanceof EmptyContent) {
+            return factory.canShowContent(content2, context) && factory.wantShowContent(content2, context);
+        }
+        return content2 instanceof EmptyContent && factory.canShowContent(content1, context) && factory.wantShowContent(content1, context);
+    }
 }

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/OnesideTextDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/OnesideTextDiffViewer.java
@@ -34,7 +34,7 @@ import consulo.diff.request.DiffRequest;
 import consulo.diff.util.LineCol;
 import consulo.diff.util.Side;
 import consulo.logging.Logger;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.AnAction;
 import consulo.util.collection.ContainerUtil;
@@ -48,10 +48,10 @@ import java.util.List;
 public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditorHolder> {
     public static final Logger LOG = Logger.getInstance(OnesideTextDiffViewer.class);
 
-    
+
     private final List<? extends EditorEx> myEditableEditors;
 
-    
+
     protected final SetEditorSettingsAction myEditorSettingsAction;
 
     public OnesideTextDiffViewer(DiffContext context, ContentDiffRequest request) {
@@ -79,7 +79,7 @@ public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditor
         super.onDispose();
     }
 
-    
+
     @Override
     protected TextEditorHolder createEditorHolder(EditorHolderFactory<TextEditorHolder> factory) {
         TextEditorHolder holder = super.createEditorHolder(factory);
@@ -102,12 +102,12 @@ public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditor
     // Diff
     //
 
-    
+
     public TextDiffSettingsHolder.TextDiffSettings getTextSettings() {
         return TextDiffViewerUtil.getTextSettings(myContext);
     }
 
-    
+
     protected List<AnAction> createEditorPopupActions() {
         return TextDiffViewerUtil.createEditorPopupActions();
     }
@@ -129,22 +129,22 @@ public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditor
     // Getters
     //
 
-    
+
     public List<? extends EditorEx> getEditors() {
         return Collections.singletonList(getEditor());
     }
 
-    
+
     protected List<? extends EditorEx> getEditableEditors() {
         return myEditableEditors;
     }
 
-    
+
     public EditorEx getEditor() {
         return getEditorHolder().getEditor();
     }
 
-    
+
     @Override
     public DocumentContent getContent() {
         //noinspection unchecked
@@ -165,8 +165,8 @@ public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditor
     //
 
     @Override
-    protected @Nullable Navigatable getNavigatable() {
-        return getContent().getNavigatable(LineCol.fromCaret(getEditor()));
+    protected @Nullable Navigable getNavigable() {
+        return getContent().getNavigable(LineCol.fromCaret(getEditor()));
     }
 
     public static boolean canShowRequest(DiffContext context, DiffRequest request) {
@@ -179,11 +179,11 @@ public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditor
 
     private class MyOpenInEditorWithMouseAction extends OpenInEditorWithMouseAction {
         @Override
-        protected Navigatable getNavigatable(Editor editor, int line) {
+        protected Navigable getNavigable(Editor editor, int line) {
             if (editor != getEditor()) {
                 return null;
             }
-            return getContent().getNavigatable(new LineCol(line));
+            return getContent().getNavigable(new LineCol(line));
         }
     }
 
@@ -200,7 +200,7 @@ public abstract class OnesideTextDiffViewer extends OnesideDiffViewer<TextEditor
     }
 
     protected abstract class MyInitialScrollPositionHelper extends InitialScrollPositionSupport.TwosideInitialScrollHelper {
-        
+
         @Override
         protected List<? extends Editor> getEditors() {
             return OnesideTextDiffViewer.this.getEditors();

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/ThreesideTextDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/ThreesideTextDiffViewer.java
@@ -39,7 +39,7 @@ import consulo.diff.util.LineCol;
 import consulo.diff.util.Side;
 import consulo.diff.util.ThreeSide;
 import consulo.document.event.DocumentEvent;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.AnAction;
 import consulo.util.collection.ContainerUtil;
@@ -55,13 +55,11 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
    
     private final List<? extends EditorEx> myEditableEditors;
 
-   
     private final MyVisibleAreaListener myVisibleAreaListener1 = new MyVisibleAreaListener(Side.LEFT);
    
     private final MyVisibleAreaListener myVisibleAreaListener2 = new MyVisibleAreaListener(Side.RIGHT);
     protected SyncScrollSupport.@Nullable ThreesideSyncScrollSupport mySyncScrollSupport;
 
-   
     protected final SetEditorSettingsAction myEditorSettingsAction;
 
     public ThreesideTextDiffViewer(DiffContext context, ContentDiffRequest request) {
@@ -93,7 +91,6 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
         super.onDispose();
     }
 
-   
     @Override
     protected List<TextEditorHolder> createEditorHolders(EditorHolderFactory<TextEditorHolder> factory) {
         List<TextEditorHolder> holders = super.createEditorHolders(factory);
@@ -171,12 +168,10 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
     // Diff
     //
 
-   
     public TextDiffSettingsHolder.TextDiffSettings getTextSettings() {
         return TextDiffViewerUtil.getTextSettings(myContext);
     }
 
-   
     protected List<AnAction> createEditorPopupActions() {
         return TextDiffViewerUtil.createEditorPopupActions();
     }
@@ -192,23 +187,19 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
     // Getters
     //
 
-   
     public EditorEx getCurrentEditor() {
         return getEditor(getCurrentSide());
     }
 
-   
     public DocumentContent getCurrentContent() {
         return getContent(getCurrentSide());
     }
 
-   
     protected List<? extends DocumentContent> getContents() {
         //noinspection unchecked
         return (List) myRequest.getContents();
     }
 
-   
     public List<? extends EditorEx> getEditors() {
         if (myEditors == null) {
             myEditors = ContainerUtil.map(getEditorHolders(), TextEditorHolder::getEditor);
@@ -216,17 +207,14 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
         return myEditors;
     }
 
-   
     protected List<? extends EditorEx> getEditableEditors() {
         return myEditableEditors;
     }
 
-   
     public EditorEx getEditor(ThreeSide side) {
         return side.select(getEditors());
     }
 
-   
     public DocumentContent getContent(ThreeSide side) {
         return side.select(getContents());
     }
@@ -257,12 +245,7 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
     protected abstract SyncScrollSupport.@Nullable SyncScrollable getSyncScrollable(Side side);
 
     @RequiredUIAccess
-   
-    protected LogicalPosition transferPosition(
-        ThreeSide baseSide,
-        ThreeSide targetSide,
-        LogicalPosition position
-    ) {
+    protected LogicalPosition transferPosition(ThreeSide baseSide, ThreeSide targetSide, LogicalPosition position) {
         if (mySyncScrollSupport == null) {
             return position;
         }
@@ -303,8 +286,8 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
     //
 
     @Override
-    protected @Nullable Navigatable getNavigatable() {
-        return getCurrentContent().getNavigatable(LineCol.fromCaret(getCurrentEditor()));
+    protected @Nullable Navigable getNavigable() {
+        return getCurrentContent().getNavigable(LineCol.fromCaret(getCurrentEditor()));
     }
 
     public static boolean canShowRequest(DiffContext context, DiffRequest request) {
@@ -317,13 +300,13 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
 
     private class MyOpenInEditorWithMouseAction extends OpenInEditorWithMouseAction {
         @Override
-        protected Navigatable getNavigatable(Editor editor, int line) {
+        protected Navigable getNavigable(Editor editor, int line) {
             ThreeSide side = getEditorSide(editor);
             if (side == null) {
                 return null;
             }
 
-            return getContent(side).getNavigatable(new LineCol(line));
+            return getContent(side).getNavigable(new LineCol(line));
         }
     }
 
@@ -346,7 +329,6 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
     }
 
     private class MyVisibleAreaListener implements VisibleAreaListener {
-       
         Side mySide;
 
         public MyVisibleAreaListener(Side side) {
@@ -364,7 +346,6 @@ public abstract class ThreesideTextDiffViewer extends ThreesideDiffViewer<TextEd
     }
 
     protected abstract class MyInitialScrollPositionHelper extends InitialScrollPositionSupport.ThreesideInitialScrollHelper {
-       
         @Override
         protected List<? extends Editor> getEditors() {
             return ThreesideTextDiffViewer.this.getEditors();

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/TwosideDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/TwosideDiffViewer.java
@@ -29,7 +29,7 @@ import consulo.diff.request.ContentDiffRequest;
 import consulo.diff.request.DiffRequest;
 import consulo.diff.util.Side;
 import consulo.disposer.Disposer;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.util.dataholder.Key;
 import consulo.virtualFileSystem.VirtualFile;
@@ -40,155 +40,160 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class TwosideDiffViewer<T extends EditorHolder> extends ListenerDiffViewerBase {
-  
-  protected final SimpleDiffPanel myPanel;
-  
-  protected final TwosideContentPanel myContentPanel;
 
-  
-  private final List<T> myHolders;
+    protected final SimpleDiffPanel myPanel;
 
-  
-  private final FocusTrackerSupport<Side> myFocusTrackerSupport;
+    protected final TwosideContentPanel myContentPanel;
 
-  public TwosideDiffViewer(DiffContext context, ContentDiffRequest request, EditorHolderFactory<T> factory) {
-    super(context, request);
+    private final List<T> myHolders;
 
-    myHolders = createEditorHolders(factory);
+    private final FocusTrackerSupport<Side> myFocusTrackerSupport;
 
-    myFocusTrackerSupport = new FocusTrackerSupport.Twoside(myHolders);
-    myContentPanel = TwosideContentPanel.createFromHolders(myHolders);
+    public TwosideDiffViewer(DiffContext context, ContentDiffRequest request, EditorHolderFactory<T> factory) {
+        super(context, request);
 
-    myPanel = new SimpleDiffPanel(myContentPanel, this, context);
-  }
+        myHolders = createEditorHolders(factory);
 
-  @RequiredUIAccess
-  @Override
-  protected void onInit() {
-    super.onInit();
-    myPanel.setPersistentNotifications(AWTDiffUtil.getCustomNotifications(myContext, myRequest));
-    myContentPanel.setTitles(createTitles());
-  }
+        myFocusTrackerSupport = new FocusTrackerSupport.Twoside(myHolders);
+        myContentPanel = TwosideContentPanel.createFromHolders(myHolders);
 
-  @Override
-  @RequiredUIAccess
-  protected void onDispose() {
-    destroyEditorHolders();
-    super.onDispose();
-  }
-
-  @Override
-  @RequiredUIAccess
-  protected void processContextHints() {
-    super.processContextHints();
-    myFocusTrackerSupport.processContextHints(myRequest, myContext);
-  }
-
-  @Override
-  @RequiredUIAccess
-  protected void updateContextHints() {
-    super.updateContextHints();
-    myFocusTrackerSupport.updateContextHints(myRequest, myContext);
-  }
-
-  //
-  // Editors
-  //
-
-  
-  protected List<T> createEditorHolders(EditorHolderFactory<T> factory) {
-    List<DiffContent> contents = myRequest.getContents();
-
-    List<T> holders = new ArrayList<>(2);
-    for (int i = 0; i < 2; i++) {
-      DiffContent content = contents.get(i);
-      holders.add(factory.create(content, myContext));
+        myPanel = new SimpleDiffPanel(myContentPanel, this, context);
     }
-    return holders;
-  }
 
-  private void destroyEditorHolders() {
-    for (T holder : myHolders) {
-      Disposer.dispose(holder);
+    @RequiredUIAccess
+    @Override
+    protected void onInit() {
+        super.onInit();
+        myPanel.setPersistentNotifications(AWTDiffUtil.getCustomNotifications(myContext, myRequest));
+        myContentPanel.setTitles(createTitles());
     }
-  }
 
-  
-  protected List<JComponent> createTitles() {
-    return AWTDiffUtil.createSyncHeightComponents(AWTDiffUtil.createSimpleTitles(myRequest));
-  }
-
-  //
-  // Getters
-  //
-
-  
-  @Override
-  public JComponent getComponent() {
-    return myPanel;
-  }
-
-  @Override
-  public @Nullable JComponent getPreferredFocusedComponent() {
-    if (!myPanel.isGoodContent()) return null;
-    return getCurrentEditorHolder().getPreferredFocusedComponent();
-  }
-
-  
-  public Side getCurrentSide() {
-    return myFocusTrackerSupport.getCurrentSide();
-  }
-
-  protected void setCurrentSide(Side side) {
-    myFocusTrackerSupport.setCurrentSide(side);
-  }
-
-  
-  protected List<T> getEditorHolders() {
-    return myHolders;
-  }
-
-  
-  protected T getCurrentEditorHolder() {
-    return getCurrentSide().select(getEditorHolders());
-  }
-
-  @Override
-  public @Nullable Object getData(Key<?> dataId) {
-    if (VirtualFile.KEY == dataId) {
-      return DiffImplUtil.getVirtualFile(myRequest, getCurrentSide());
+    @Override
+    @RequiredUIAccess
+    protected void onDispose() {
+        destroyEditorHolders();
+        super.onDispose();
     }
-    else if (DiffDataKeys.CURRENT_CONTENT == dataId) {
-      return getCurrentSide().select(myRequest.getContents());
+
+    @Override
+    @RequiredUIAccess
+    protected void processContextHints() {
+        super.processContextHints();
+        myFocusTrackerSupport.processContextHints(myRequest, myContext);
     }
-    return super.getData(dataId);
-  }
 
-  //
-  // Misc
-  //
-
-  @Override
-  protected @Nullable Navigatable getNavigatable() {
-    Navigatable navigatable1 = getCurrentSide().select(getRequest().getContents()).getNavigatable();
-    if (navigatable1 != null) return navigatable1;
-    return getCurrentSide().other().select(getRequest().getContents()).getNavigatable();
-  }
-
-  public static <T extends EditorHolder> boolean canShowRequest(DiffContext context,
-                                                                DiffRequest request,
-                                                                EditorHolderFactory<T> factory) {
-    if (!(request instanceof ContentDiffRequest)) return false;
-
-    List<DiffContent> contents = ((ContentDiffRequest)request).getContents();
-    if (contents.size() != 2) return false;
-
-    boolean canShow = true;
-    boolean wantShow = false;
-    for (DiffContent content : contents) {
-      canShow &= factory.canShowContent(content, context);
-      wantShow |= factory.wantShowContent(content, context);
+    @Override
+    @RequiredUIAccess
+    protected void updateContextHints() {
+        super.updateContextHints();
+        myFocusTrackerSupport.updateContextHints(myRequest, myContext);
     }
-    return canShow && wantShow;
-  }
+
+    //
+    // Editors
+    //
+
+    protected List<T> createEditorHolders(EditorHolderFactory<T> factory) {
+        List<DiffContent> contents = myRequest.getContents();
+
+        List<T> holders = new ArrayList<>(2);
+        for (int i = 0; i < 2; i++) {
+            DiffContent content = contents.get(i);
+            holders.add(factory.create(content, myContext));
+        }
+        return holders;
+    }
+
+    private void destroyEditorHolders() {
+        for (T holder : myHolders) {
+            Disposer.dispose(holder);
+        }
+    }
+
+    protected List<JComponent> createTitles() {
+        return AWTDiffUtil.createSyncHeightComponents(AWTDiffUtil.createSimpleTitles(myRequest));
+    }
+
+    //
+    // Getters
+    //
+
+    @Override
+    public JComponent getComponent() {
+        return myPanel;
+    }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        if (!myPanel.isGoodContent()) {
+            return null;
+        }
+        return getCurrentEditorHolder().getPreferredFocusedComponent();
+    }
+
+
+    public Side getCurrentSide() {
+        return myFocusTrackerSupport.getCurrentSide();
+    }
+
+    protected void setCurrentSide(Side side) {
+        myFocusTrackerSupport.setCurrentSide(side);
+    }
+
+
+    protected List<T> getEditorHolders() {
+        return myHolders;
+    }
+
+
+    protected T getCurrentEditorHolder() {
+        return getCurrentSide().select(getEditorHolders());
+    }
+
+    @Override
+    public @Nullable Object getData(Key<?> dataId) {
+        if (VirtualFile.KEY == dataId) {
+            return DiffImplUtil.getVirtualFile(myRequest, getCurrentSide());
+        }
+        else if (DiffDataKeys.CURRENT_CONTENT == dataId) {
+            return getCurrentSide().select(myRequest.getContents());
+        }
+        return super.getData(dataId);
+    }
+
+    //
+    // Misc
+    //
+
+    @Override
+    protected @Nullable Navigable getNavigable() {
+        Navigable navigable1 = getCurrentSide().select(getRequest().getContents()).getNavigable();
+        if (navigable1 != null) {
+            return navigable1;
+        }
+        return getCurrentSide().other().select(getRequest().getContents()).getNavigable();
+    }
+
+    public static <T extends EditorHolder> boolean canShowRequest(
+        DiffContext context,
+        DiffRequest request,
+        EditorHolderFactory<T> factory
+    ) {
+        if (!(request instanceof ContentDiffRequest contentDiffRequest)) {
+            return false;
+        }
+
+        List<DiffContent> contents = contentDiffRequest.getContents();
+        if (contents.size() != 2) {
+            return false;
+        }
+
+        boolean canShow = true;
+        boolean wantShow = false;
+        for (DiffContent content : contents) {
+            canShow &= factory.canShowContent(content, context);
+            wantShow |= factory.wantShowContent(content, context);
+        }
+        return canShow && wantShow;
+    }
 }

--- a/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/TwosideTextDiffViewer.java
+++ b/modules/desktop-awt/desktop-awt-ide-impl/src/main/java/consulo/desktop/awt/internal/diff/util/side/TwosideTextDiffViewer.java
@@ -41,7 +41,7 @@ import consulo.diff.util.LineCol;
 import consulo.diff.util.Side;
 import consulo.document.event.DocumentEvent;
 import consulo.logging.Logger;
-import consulo.navigation.Navigatable;
+import consulo.navigation.Navigable;
 import consulo.ui.annotation.RequiredUIAccess;
 import consulo.ui.ex.action.AnAction;
 import consulo.ui.ex.action.AnActionEvent;
@@ -55,14 +55,11 @@ import java.util.List;
 public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditorHolder> {
     public static final Logger LOG = Logger.getInstance(TwosideTextDiffViewer.class);
 
-   
     private final List<? extends EditorEx> myEditableEditors;
     private @Nullable List<? extends EditorEx> myEditors;
 
-   
     protected final SetEditorSettingsAction myEditorSettingsAction;
 
-   
     private final MyVisibleAreaListener myVisibleAreaListener = new MyVisibleAreaListener();
 
     private SyncScrollSupport.@Nullable TwosideSyncScrollSupport mySyncScrollSupport;
@@ -103,7 +100,6 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
         super.onDispose();
     }
 
-   
     @Override
     protected List<TextEditorHolder> createEditorHolders(EditorHolderFactory<TextEditorHolder> factory) {
         List<TextEditorHolder> holders = super.createEditorHolders(factory);
@@ -124,7 +120,6 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
         return holders;
     }
 
-   
     @Override
     protected List<JComponent> createTitles() {
         return AWTDiffUtil.createSyncHeightComponents(AWTDiffUtil.createTextTitles(myRequest, getEditors()));
@@ -134,12 +129,10 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
     // Diff
     //
 
-   
     public TextDiffSettingsHolder.TextDiffSettings getTextSettings() {
         return TextDiffViewerUtil.getTextSettings(myContext);
     }
 
-   
     protected List<AnAction> createEditorPopupActions() {
         return TextDiffViewerUtil.createEditorPopupActions();
     }
@@ -194,13 +187,11 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
     // Getters
     //
 
-   
     protected List<? extends DocumentContent> getContents() {
         //noinspection unchecked
         return (List) myRequest.getContents();
     }
 
-   
     public List<? extends EditorEx> getEditors() {
         if (myEditors == null) {
             myEditors = ContainerUtil.map(getEditorHolders(), holder -> holder.getEditor());
@@ -208,32 +199,26 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
         return myEditors;
     }
 
-   
     protected List<? extends EditorEx> getEditableEditors() {
         return myEditableEditors;
     }
 
-   
     public EditorEx getCurrentEditor() {
         return getEditor(getCurrentSide());
     }
 
-   
     public DocumentContent getCurrentContent() {
         return getContent(getCurrentSide());
     }
 
-   
     public EditorEx getEditor1() {
         return getEditor(Side.LEFT);
     }
 
-   
     public EditorEx getEditor2() {
         return getEditor(Side.RIGHT);
     }
 
-   
     public EditorEx getEditor(Side side) {
         return side.select(getEditors());
     }
@@ -243,12 +228,10 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
         return side.select(getContents());
     }
 
-   
     public DocumentContent getContent1() {
         return getContent(Side.LEFT);
     }
 
-   
     public DocumentContent getContent2() {
         return getContent(Side.RIGHT);
     }
@@ -262,7 +245,6 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
     //
 
     @RequiredUIAccess
-   
     protected LineCol transferPosition(Side baseSide, LineCol position) {
         if (mySyncScrollSupport == null) {
             return position;
@@ -285,17 +267,17 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
 
     @Override
     @RequiredUIAccess
-    protected @Nullable Navigatable getNavigatable() {
+    protected @Nullable Navigable getNavigable() {
         Side side = getCurrentSide();
 
         LineCol position = LineCol.fromCaret(getEditor(side));
-        Navigatable navigatable = getContent(side).getNavigatable(position);
-        if (navigatable != null) {
-            return navigatable;
+        Navigable navigable = getContent(side).getNavigable(position);
+        if (navigable != null) {
+            return navigable;
         }
 
         LineCol otherPosition = transferPosition(side, position);
-        return getContent(side.other()).getNavigatable(otherPosition);
+        return getContent(side.other()).getNavigable(otherPosition);
     }
 
     public static boolean canShowRequest(DiffContext context, DiffRequest request) {
@@ -334,13 +316,13 @@ public abstract class TwosideTextDiffViewer extends TwosideDiffViewer<TextEditor
 
     private class MyOpenInEditorWithMouseAction extends OpenInEditorWithMouseAction {
         @Override
-        protected Navigatable getNavigatable(Editor editor, int line) {
+        protected Navigable getNavigable(Editor editor, int line) {
             Side side = Side.fromValue(getEditors(), editor);
             if (side == null) {
                 return null;
             }
 
-            return getContent(side).getNavigatable(new LineCol(line));
+            return getContent(side).getNavigable(new LineCol(line));
         }
     }
 


### PR DESCRIPTION
Instances should be created using XxNavigatable and then used as XxNavigable, so number of typos is reduced. Old XxNavigatable are marked as deprecated. Adding RRA/RWA/RUI annotations. Some reformatting / refactoring.